### PR TITLE
Integration der Validierung

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
-language: c
+language: minimal
 
 before_script:
   - sudo apt-get install -qq libxml2-utils
 
 script:
-  - "xmllint --noout --schema xsd/siri.xsd examples/siri_exa_framework/*xml examples/siri_exm_CM/*xml examples/siri_exm_CT/*xml examples/siri_exm_ET/*xml examples/siri_exm_FM/*xml examples/siri_exm_GM/*xml examples/siri_exm_PT/*xml examples/siri_exm_SM/*xml examples/siri_exm_ST/*xml examples/siri_exm_SX/*xml examples/siri_exm_VM/*xml examples/siri_exu_capability/*xml examples/siri_exu_discovery/*xml"
+  - bash xmllint-check.sh

--- a/examples/siri_exm_SM/exs_stopMonitoring_response_complex.xml
+++ b/examples/siri_exm_SM/exs_stopMonitoring_response_complex.xml
@@ -24,8 +24,8 @@
    <ValidUntil>2004-12-17T09:30:47-05:00</ValidUntil>
    <ShortestPossibleCycle>PT3M</ShortestPossibleCycle>
    <MonitoringRef>HLTST011</MonitoringRef>
-   <MonitoringName xml:lang="en">British Museum Stop A</MonitoringName>
-   <MonitoringName xml:lang="fr">Musee Britannique Halte A</MonitoringName>
+   <MonitoringName xml:lang="EN">British Museum Stop A</MonitoringName>
+   <MonitoringName xml:lang="FR">Musee Britannique Halte A</MonitoringName>
    <!--====FIRST ARRIVAL ============================================ -->
    <MonitoredStopVisit>
     <RecordedAtTime>2004-12-17T09:25:46-05:00</RecordedAtTime>
@@ -58,8 +58,8 @@
       <PlaceName>Roman Road</PlaceName>
      </Via>
      <DestinationRef>PLACE45</DestinationRef>
-     <DestinationName xml:lang="en">Paradise Park</DestinationName>
-     <DestinationName xml:lang="fr">Parc du Paradis</DestinationName>
+     <DestinationName xml:lang="EN">Paradise Park</DestinationName>
+     <DestinationName xml:lang="FR">Parc du Paradis</DestinationName>
      <VehicleJourneyName xml:lang="EN">Boris Special</VehicleJourneyName>
      <!-- JOURNEY INFO GROUP -->
      <JourneyNote>Kensall Green</JourneyNote>
@@ -95,8 +95,8 @@
       <PreviousCall>
        <StopPointRef>HLT0010</StopPointRef>
        <VisitNumber>2</VisitNumber>
-       <StopPointName xml:lang="en">Town Hall</StopPointName>
-       <StopPointName xml:lang="en">Hotel de Ville</StopPointName>
+       <StopPointName xml:lang="EN">Town Hall</StopPointName>
+       <StopPointName xml:lang="EN">Hotel de Ville</StopPointName>
        <VehicleAtStop>false</VehicleAtStop>
        <AimedDepartureTime>2004-12-17T09:32:43-05:00</AimedDepartureTime>
        <ActualDepartureTime>2004-12-17T09:32:43-05:00</ActualDepartureTime>
@@ -125,8 +125,8 @@
       <OnwardCall>
        <StopPointRef>HLTST012</StopPointRef>
        <VisitNumber>4</VisitNumber>
-       <StopPointName xml:lang="en">Church</StopPointName>
-       <StopPointName xml:lang="fr">Eglise</StopPointName>
+       <StopPointName xml:lang="EN">Church</StopPointName>
+       <StopPointName xml:lang="FR">Eglise</StopPointName>
        <VehicleAtStop>false</VehicleAtStop>
        <AimedArrivalTime>2004-12-17T09:30:56-05:00</AimedArrivalTime>
        <ExpectedArrivalTime>2004-12-17T09:30:56-05:00</ExpectedArrivalTime>
@@ -267,7 +267,7 @@
        </ExpectedDeparturePredictionQuality>
        <AimedLatestPassengerAccessTime>2004-12-17T09:55:47-05:00</AimedLatestPassengerAccessTime>
        <DepartureStatus>onTime</DepartureStatus>
-       <DepartureProximityText xml:lang="en">Approaching stop</DepartureProximityText>
+       <DepartureProximityText xml:lang="EN">Approaching stop</DepartureProximityText>
        <DeparturePlatformName>2</DeparturePlatformName>
        <AimedHeadwayInterval>PT10M</AimedHeadwayInterval>
        <ExpectedHeadwayInterval>PT11M</ExpectedHeadwayInterval>

--- a/examples/siri_exm_SX/exx_situationExchangeResponse.xml
+++ b/examples/siri_exm_SX/exx_situationExchangeResponse.xml
@@ -40,7 +40,7 @@
      <Severity>severe</Severity>
      <Audience>public</Audience>
      <ReportType>point</ReportType>
-     <Summary overridden="true">Bomb at Barchester station</Summary>
+     <Summary overridden="true" xml:lang="EN">Bomb at Barchester station</Summary>
      <Description overridden="true" xml:lang="EN">Building evacuated. AVoid station untile furtehr notice</Description>
      <Affects>
       <Operators>
@@ -75,8 +75,8 @@
        <Period>
         <StartTime>2001-12-17T09:30:47.0Z</StartTime>
        </Period>
-       <Condition>pti13_0</Condition>
-       <Severity>pti26_0</Severity>
+       <Condition>unknown</Condition>
+       <Severity>unknown</Severity>
        <Blocking>
         <JourneyPlanner>true</JourneyPlanner>
         <RealTime>true</RealTime>
@@ -134,7 +134,7 @@
      <Severity>severe</Severity>
      <Audience>public</Audience>
      <ReportType>point</ReportType>
-     <Summary overridden="true">Jam on the access road to Barchester Station</Summary>
+     <Summary overridden="true" xml:lang="EN">Jam on the access road to Barchester Station</Summary>
      <Description overridden="true" xml:lang="EN">Grislock and panic</Description>
      <Affects>
       <Operators>
@@ -169,7 +169,7 @@
        <Period>
         <StartTime>2001-12-17T09:30:47.0Z</StartTime>
        </Period>
-       <Condition>delayed</Condition>
+       <Condition>delay</Condition>
        <Severity>severe</Severity>
       </Consequence>
      </Consequences>
@@ -202,8 +202,8 @@
 							<d2:sourceIdentification>SRA</d2:sourceIdentification>
 							<d2:sourceName>
 								<d2:values>
-									<d2:value lang="se">Vägverket</d2:value>
-									<d2:value lang="en">Swedish Road Administration</d2:value>
+									<d2:value xml:lang="se">Vägverket</d2:value>
+									<d2:value xml:lang="en">Swedish Road Administration</d2:value>
 								</d2:values>
 							</d2:sourceName>
 							<d2:sourceType>roadAuthorities</d2:sourceType>
@@ -224,8 +224,8 @@
 						<d2:generalPublicComment>
 							<d2:comment>
 								<d2:values>
-									<d2:value lang="se">Detta är en svensk olycka</d2:value>
-									<d2:value lang="en">This is a swedish accident</d2:value>
+									<d2:value xml:lang="se">Detta är en svensk olycka</d2:value>
+									<d2:value xml:lang="en">This is a swedish accident</d2:value>
 								</d2:values>
 							</d2:comment>
 						</d2:generalPublicComment>

--- a/examples/siri_exm_SX/exx_situationExchange_ATOC.xml
+++ b/examples/siri_exm_SX/exx_situationExchange_ATOC.xml
@@ -29,7 +29,7 @@
  <siri:Severity>severe</siri:Severity>
  <siri:Audience>public</siri:Audience>
  <siri:ReportType>point</siri:ReportType>
- <siri:Summary overridden="true">Bomb at Barchester station</siri:Summary>
+ <siri:Summary overridden="true" xml:lang="EN">Bomb at Barchester station</siri:Summary>
  <siri:Description overridden="true" xml:lang="EN">Building evacuated. AVoid station untile furtehr notice</siri:Description>
  <siri:Affects>
   <siri:Operators>

--- a/examples/siri_exm_SX/exx_situationExchange_ATOC.xml
+++ b/examples/siri_exm_SX/exx_situationExchange_ATOC.xml
@@ -64,7 +64,7 @@
    <siri:Period>
     <siri:StartTime>2001-12-17T09:30:47.0Z</siri:StartTime>
    </siri:Period>
-   <siri:Condition>delayed</siri:Condition>
+   <siri:Condition>delay</siri:Condition>
    <siri:Severity>severe</siri:Severity>
    <siri:Blocking>
     <siri:JourneyPlanner>true</siri:JourneyPlanner>

--- a/examples/siri_exm_SX/exx_situationExchange_Pt.xml
+++ b/examples/siri_exm_SX/exx_situationExchange_Pt.xml
@@ -29,7 +29,7 @@
  <siri:Severity>severe</siri:Severity>
  <siri:Audience>public</siri:Audience>
  <siri:ReportType>point</siri:ReportType>
- <siri:Summary overridden="true">Bomb at Barchester station</siri:Summary>
+ <siri:Summary overridden="true" xml:lang="EN">Bomb at Barchester station</siri:Summary>
  <siri:Description overridden="true" xml:lang="EN">Building evacuated. AVoid station untile furtehr notice</siri:Description>
  <siri:Affects>
   <siri:Operators>

--- a/examples/siri_exm_SX/exx_situationExchange_Pt.xml
+++ b/examples/siri_exm_SX/exx_situationExchange_Pt.xml
@@ -64,7 +64,7 @@
    <siri:Period>
     <siri:StartTime>2001-12-17T09:30:47.0Z</siri:StartTime>
    </siri:Period>
-   <siri:Condition>delayed</siri:Condition>
+   <siri:Condition>delay</siri:Condition>
    <siri:Severity>severe</siri:Severity>
    <siri:Blocking>
     <siri:JourneyPlanner>true</siri:JourneyPlanner>

--- a/examples/siri_exm_SX/exx_situationExchange_request.xml
+++ b/examples/siri_exm_SX/exx_situationExchange_request.xml
@@ -24,7 +24,7 @@
    <RequestTimestamp>2004-12-17T09:30:47-05:00</RequestTimestamp>
    <!--=======TOPIC ===================================== -->
    <StartTime>2004-12-17T09:30:47-05:00 </StartTime>
-   <VehicleMode>rail</VehicleMode>
+   <VehicleMode>railwayService</VehicleMode>
    <Scope>network</Scope>
    <!--=======POLICY==========================================-->
   </SituationExchangeRequest>

--- a/examples/siri_exm_SX/exx_situationExchange_response.xml
+++ b/examples/siri_exm_SX/exx_situationExchange_response.xml
@@ -75,7 +75,7 @@
        <Period>
         <StartTime>2001-12-17T09:30:47.0Z</StartTime>
        </Period>
-       <Condition>pti13_0</Condition>
+       <Condition>unknown</Condition>
        <Severity>pti26_0</Severity>
        <Blocking>
         <JourneyPlanner>true</JourneyPlanner>

--- a/examples/siri_exm_SX/exx_situationExchange_response.xml
+++ b/examples/siri_exm_SX/exx_situationExchange_response.xml
@@ -40,7 +40,7 @@
      <Severity>severe</Severity>
      <Audience>public</Audience>
      <ReportType>point</ReportType>
-     <Summary overridden="true">Bomb at Barchester station</Summary>
+     <Summary overridden="true" xml:lang="EN">Bomb at Barchester station</Summary>
      <Description overridden="true" xml:lang="EN">Building evacuated. AVoid station untile further notice</Description>
      <Affects>
       <Operators>
@@ -134,7 +134,7 @@
      <Severity>severe</Severity>
      <Audience>public</Audience>
      <ReportType>point</ReportType>
-     <Summary overridden="true">Jam on the access road to Barchester Station</Summary>
+     <Summary overridden="true" xml:lang="EN">Jam on the access road to Barchester Station</Summary>
      <Description overridden="true" xml:lang="EN">Grislock and panic</Description>
      <Affects>
       <Operators>

--- a/examples/siri_exm_SX/exx_situationExchange_response.xml
+++ b/examples/siri_exm_SX/exx_situationExchange_response.xml
@@ -169,7 +169,7 @@
        <Period>
         <StartTime>2001-12-17T09:30:47.0Z</StartTime>
        </Period>
-       <Condition>delayed</Condition>
+       <Condition>delay</Condition>
        <Severity>severe</Severity>
       </Consequence>
      </Consequences>

--- a/examples/siri_exm_SX/exx_situationExchange_road.xml
+++ b/examples/siri_exm_SX/exx_situationExchange_road.xml
@@ -29,7 +29,7 @@
  <siri:Severity>severe</siri:Severity>
  <siri:Audience>public</siri:Audience>
  <siri:ReportType>point</siri:ReportType>
- <siri:Summary overridden="true">Jam on the access road to Barchester Station</siri:Summary>
+ <siri:Summary overridden="true" xml:lang="EN">Jam on the access road to Barchester Station</siri:Summary>
  <siri:Description overridden="true" xml:lang="EN">Grislock and panic</siri:Description>
  <siri:Affects>
   <siri:Operators>

--- a/examples/siri_exm_SX/exx_situationExchange_road.xml
+++ b/examples/siri_exm_SX/exx_situationExchange_road.xml
@@ -64,7 +64,7 @@
    <siri:Period>
     <siri:StartTime>2001-12-17T09:30:47.0Z</siri:StartTime>
    </siri:Period>
-   <siri:Condition>delayed</siri:Condition>
+   <siri:Condition>delay</siri:Condition>
    <siri:Severity>severe</siri:Severity>
   </siri:Consequence>
  </siri:Consequences>

--- a/examples/siri_exu_capability/exd_allServices_capabilitiesResponse.xml
+++ b/examples/siri_exu_capability/exd_allServices_capabilitiesResponse.xml
@@ -487,8 +487,7 @@
      <CheckOperatorRef>false</CheckOperatorRef>
      <CheckLineRef>false</CheckLineRef>
     </AccessControl>
-    <ResponseFeatures>
-    </ResponseFeatures>
+    <ResponseFeatures/>
    </SituationExchangeServiceCapabilities>
   </SituationExchangeCapabilitiesResponse>
  </CapabilitiesResponse>

--- a/examples/siri_exu_capability/exd_allServices_capabilitiesResponse.xml
+++ b/examples/siri_exu_capability/exd_allServices_capabilitiesResponse.xml
@@ -476,7 +476,7 @@
     <RequestPolicy>
      <NationalLanguage>en</NationalLanguage>
      <GmlCoordinateFormat>WGS84</GmlCoordinateFormat>
-     <HasMaximumFacilityStatus>true</HasMaximumFacilityStatus>
+     <HasMaximumNumberOfSituations>true</HasMaximumNumberOfSituations>
     </RequestPolicy>
     <SubscriptionPolicy>
      <HasIncrementalUpdates>true</HasIncrementalUpdates>
@@ -488,8 +488,6 @@
      <CheckLineRef>false</CheckLineRef>
     </AccessControl>
     <ResponseFeatures>
-     <HasRemedy>true</HasRemedy>
-     <HasFacilityLocation>true</HasFacilityLocation>
     </ResponseFeatures>
    </SituationExchangeServiceCapabilities>
   </SituationExchangeCapabilitiesResponse>


### PR DESCRIPTION
Damit die Beispiele validiert werden können, müssen diese an das aktuelle XSD angepasst werden.

Sowohl Änderungen der SIRI-CEN-Gruppe (für die original SIRI Beispiele), als auch die UMS Besonderheiten für Version 1 von 731-2 müssen berücksichtigt sein.

Travis soll fortan mit demselben Skript zur Validierung arbeiten, welches auch über die Kommandozeile für die Entwicklung genutzt werden kann. Intern wird xmllint zur Prüfung und Validierung verwendet (wie von der SIRI-CEN-Gruppe).