### PR TITLE
Inkompatibles Attribut "lang" auf Stand SIRI zurücksetzen

### DIFF
--- a/xsd/siri_model/siri_situation-v2.0.xsd
+++ b/xsd/siri_model/siri_situation-v2.0.xsd
@@ -666,7 +666,7 @@ Rail transport, Roads and road transport
      </xsd:sequence>
     </xsd:complexType>
    </xsd:element>
-   <xsd:element name="PublicationWindow" type="HalfOpenTimestampOutputRangeStructure" minOccurs="0">
+   <xsd:element name="PublicationWindow" type="HalfOpenTimestampOutputRangeStructure" minOccurs="0" maxOccurs="unbounded">
     <xsd:annotation>
      <xsd:documentation>Publication Window for SITUATION if different from validity period.</xsd:documentation>
     </xsd:annotation>

--- a/xsd/siri_model/siri_situation-v2.0.xsd
+++ b/xsd/siri_model/siri_situation-v2.0.xsd
@@ -666,7 +666,7 @@ Rail transport, Roads and road transport
      </xsd:sequence>
     </xsd:complexType>
    </xsd:element>
-   <xsd:element name="PublicationWindow" type="HalfOpenTimestampOutputRangeStructure" minOccurs="0" maxOccurs="unbounded">
+   <xsd:element name="PublicationWindow" type="HalfOpenTimestampOutputRangeStructure" minOccurs="0">
     <xsd:annotation>
      <xsd:documentation>Publication Window for SITUATION if different from validity period.</xsd:documentation>
     </xsd:annotation>
@@ -1068,8 +1068,7 @@ Rail transport, Roads and road transport
    <xsd:documentation>Type for a text that may be overridden.</xsd:documentation>
   </xsd:annotation>
   <xsd:simpleContent>
-   <xsd:extension base="PopulatedStringType">
-    <xsd:attribute ref="xml:lang" use="required"/>
+   <xsd:extension base="NaturalLanguageStringStructure">
     <xsd:attribute name="overridden" type="xsd:boolean" use="optional" default="true">
      <xsd:annotation>
       <xsd:documentation>Whether the text value has been overridden from the generated default. Default is 'true'.</xsd:documentation>


### PR DESCRIPTION
Rückwärtskompatibilität ist für das CEN SIRI Gremium ein wichtiger Punkt bei der Akzeptanz von Änderungen. Um möglichst wenige unnötige Diskussionspunkte zu haben, soll die erzeugte Inkompatibilität des Attributs "lang" zurückgenommen werden.

![image](https://user-images.githubusercontent.com/48470601/70815662-2e91d880-1dce-11ea-8745-3056d5614368.png)
Das Attribut "lang" soll wieder optional sein. In der Schrift ist dies bereits so beschrieben (siehe letzte Spalte in Tabelle)