### PR TITLE
Inkompatibles Element ParticipantRef auf Stand SIRI zurücksetzen

### DIFF
--- a/xsd/siri_model/siri_situationIdentity-v1.1.xsd
+++ b/xsd/siri_model/siri_situationIdentity-v1.1.xsd
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsd:schema xmlns="http://www.siri.org.uk/siri" xmlns:ifopt="http://www.ifopt.org.uk/ifopt" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.siri.org.uk/siri" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.1" id="siri_situationIdentity">
+ <!--
+12.06.2018 D. Rubli, Siri_XML-2.0p_a0.5:
+- ParticipantRef changed from optional to mandatory
+-->
  <xsd:annotation>
   <xsd:appinfo>
    <Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">
@@ -209,7 +213,7 @@ Rail transport, Roads and road transport
      <xsd:documentation>Unique identifier of a Country of a Participant who created Update SITUATION element. Provides namespace for VersionParticipant If absent same as.</xsd:documentation>
     </xsd:annotation>
    </xsd:element>
-   <xsd:element name="ParticipantRef" type="ParticipantRefStructure" minOccurs="0">
+   <xsd:element name="ParticipantRef" type="ParticipantRefStructure">
     <xsd:annotation>
      <xsd:documentation>Unique identifier of a Participant. Provides namespace for SITUATION.</xsd:documentation>
     </xsd:annotation>

--- a/xsd/siri_model/siri_situationIdentity-v1.1.xsd
+++ b/xsd/siri_model/siri_situationIdentity-v1.1.xsd
@@ -150,7 +150,7 @@ Rail transport, Roads and road transport
      <xsd:documentation>Unique identifier of a Country of a Participant who created SITUATION. Provides namespace for Participant If absent proided from context.</xsd:documentation>
     </xsd:annotation>
    </xsd:element>
-   <xsd:element name="ParticipantRef" type="ParticipantRefStructure">
+   <xsd:element name="ParticipantRef" type="ParticipantRefStructure" minOccurs="0">
     <xsd:annotation>
      <xsd:documentation>Unique identifier of a Participant. Provides namespace for SITUATION. If absent provdied from context.</xsd:documentation>
     </xsd:annotation>

--- a/xsd/siri_model/siri_situationIdentity-v1.1.xsd
+++ b/xsd/siri_model/siri_situationIdentity-v1.1.xsd
@@ -1,9 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsd:schema xmlns="http://www.siri.org.uk/siri" xmlns:ifopt="http://www.ifopt.org.uk/ifopt" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.siri.org.uk/siri" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.1" id="siri_situationIdentity">
- <!--
-12.06.2018 D. Rubli, Siri_XML-2.0p_a0.5:
-- ParticipantRef changed from optional to mandatory
--->
  <xsd:annotation>
   <xsd:appinfo>
    <Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">

--- a/xsd/siri_model/siri_situationIdentity-v1.1.xsd
+++ b/xsd/siri_model/siri_situationIdentity-v1.1.xsd
@@ -1,9 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsd:schema xmlns="http://www.siri.org.uk/siri" xmlns:ifopt="http://www.ifopt.org.uk/ifopt" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.siri.org.uk/siri" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.1" id="siri_situationIdentity">
- <!--
-12.06.2018 D. Rubli, Siri_XML-2.0p_a0.5:
-- ParticipantRef changed from optional to mandatory
--->
  <xsd:annotation>
   <xsd:appinfo>
    <Metadata xmlns="http://www.govtalk.gov.uk/CM/gms-xs">
@@ -213,7 +209,7 @@ Rail transport, Roads and road transport
      <xsd:documentation>Unique identifier of a Country of a Participant who created Update SITUATION element. Provides namespace for VersionParticipant If absent same as.</xsd:documentation>
     </xsd:annotation>
    </xsd:element>
-   <xsd:element name="ParticipantRef" type="ParticipantRefStructure">
+   <xsd:element name="ParticipantRef" type="ParticipantRefStructure" minOccurs="0">
     <xsd:annotation>
      <xsd:documentation>Unique identifier of a Participant. Provides namespace for SITUATION.</xsd:documentation>
     </xsd:annotation>


### PR DESCRIPTION
Rückwärtskompatibilität ist für das CEN SIRI Gremium ein wichtiger Punkt bei der Akzeptanz von Änderungen. Um möglichst wenige unnötige Diskussionspunkte zu haben, soll die erzeugte Inkompatibilität des Elements ParticipantRef zurückgenommen werden.

Das ParticipantRef Element soll wieder optional sein.
In aktueller Schrift als "mandatory" markiert, wie in SIRI -> benötigt CR zum Angleichen von SIRI Schrift/XSD.

![image](https://user-images.githubusercontent.com/48470601/70817969-00fb5e00-1dd3-11ea-8a0d-976d64d51665.png)
