### PR TITLE
Inkompatibles Element PublicationWindow auf Stand SIRI zurücksetzen

### DIFF
--- a/xsd/siri_model/siri_situation-v2.0.xsd
+++ b/xsd/siri_model/siri_situation-v2.0.xsd
@@ -666,7 +666,7 @@ Rail transport, Roads and road transport
      </xsd:sequence>
     </xsd:complexType>
    </xsd:element>
-   <xsd:element name="PublicationWindow" type="HalfOpenTimestampOutputRangeStructure" minOccurs="0" maxOccurs="unbounded">
+   <xsd:element name="PublicationWindow" type="HalfOpenTimestampOutputRangeStructure" minOccurs="0">
     <xsd:annotation>
      <xsd:documentation>Publication Window for SITUATION if different from validity period.</xsd:documentation>
     </xsd:annotation>


### PR DESCRIPTION
Rückwärtskompatibilität ist für das CEN SIRI Gremium ein wichtiger Punkt bei der Akzeptanz von Änderungen. Um möglichst wenige unnötige Diskussionspunkte zu haben, soll die erzeugte Inkompatibilität des Elements PublicationWindow zurückgenommen werden.

Siehe: https://github.com/VDVde/UMS/commit/d08507f4791cb7fef7a0161b7ee7b5e461a39e4a#r36244870