### PR TITLE
Inkompatibles Element Period auf Stand SIRI zurücksetzen

### DIFF
--- a/xsd/siri_model/siri_situation-v2.0.xsd
+++ b/xsd/siri_model/siri_situation-v2.0.xsd
@@ -1135,7 +1135,7 @@ Rail transport, Roads and road transport
    <xsd:documentation>Type for disruption.</xsd:documentation>
   </xsd:annotation>
   <xsd:sequence>
-   <xsd:element name="Period" type="HalfOpenTimestampOutputRangeStructure" minOccurs="0" maxOccurs="unbounded">
+   <xsd:element name="Period" type="HalfOpenTimestampOutputRangeStructure" minOccurs="0">
     <xsd:annotation>
      <xsd:documentation>Period of effect of disruption, if different from that of SITUATION.</xsd:documentation>
     </xsd:annotation>


### PR DESCRIPTION
Rückwärtskompatibilität ist für das CEN SIRI Gremium ein wichtiger Punkt bei der Akzeptanz von Änderungen. Um möglichst wenige unnötige Diskussionspunkte zu haben, soll die erzeugte Inkompatibilität des Elements Period zurückgenommen werden.

Siehe: https://github.com/VDVde/UMS/commit/d08507f4791cb7fef7a0161b7ee7b5e461a39e4a#r35694916