### PR TITLE
Inkompatibles Element CountryRef auf Stand SIRI zurücksetzen

### DIFF
--- a/xsd/siri_model/siri_situation-v2.0.xsd
+++ b/xsd/siri_model/siri_situation-v2.0.xsd
@@ -487,7 +487,7 @@ Rail transport, Roads and road transport
    <xsd:documentation>Type for a source, i.e. provider of information.</xsd:documentation>
   </xsd:annotation>
   <xsd:sequence>
-   <xsd:element name="CountryRef" type="xsd:NMTOKEN" minOccurs="0">
+   <xsd:element name="Country" type="xsd:NMTOKEN" minOccurs="0">
     <xsd:annotation>
      <xsd:documentation>Country of origin of source element.</xsd:documentation>
     </xsd:annotation>


### PR DESCRIPTION
Rückwärtskompatibilität ist für das CEN SIRI Gremium ein wichtiger Punkt bei der Akzeptanz von Änderungen. Um möglichst wenige unnötige Diskussionspunkte zu haben, soll die erzeugte Inkompatibilität des Elements CountryRef zurückgenommen werden.

Das CountryRef Element soll wieder Country heißen.