### PR TITLE
CR_736-029: Added predicatableDelays and hamburg examples

### DIFF
--- a/examples/hamburg_example/Use_Case_Abkehren1Seitig_S1_global_SEV.xml
+++ b/examples/hamburg_example/Use_Case_Abkehren1Seitig_S1_global_SEV.xml
@@ -1,0 +1,626 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Siri xmlns="http://www.siri.org.uk/siri" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.0" xsi:schemaLocation="http://www.siri.org.uk/siri  ../../xsd/siri.xsd">
+	<ServiceDelivery>
+		<ResponseTimestamp>2020-10-01T13:10:00+02:00</ResponseTimestamp>
+		<ProducerRef>MES</ProducerRef>
+		<SituationExchangeDelivery version="2.0">
+			<ResponseTimestamp>2020-10-01T13:10:00+02:00</ResponseTimestamp>
+			<Situations>
+				<PtSituationElement>
+					<CreationTime>2020-10-01T13:20:00+02:00</CreationTime>
+					<ParticipantRef>S-Bahn-HH</ParticipantRef>
+					<SituationNumber>201001001</SituationNumber>
+					<Version>2</Version>
+					<Source>
+						<SourceType>web</SourceType>
+						<AgentReference>S-DB-HH</AgentReference>
+						<Name xml:lang="DE">S-Bahn MES Disponent</Name>
+						<TimeOfCommunication>2020-10-01T13:08:00+02:00</TimeOfCommunication>
+					</Source>
+					<VersionedAtTime>2020-10-01T13:20:00+02:00</VersionedAtTime>
+					<Progress>published</Progress>
+					<ValidityPeriod>
+						<StartTime>2020-10-01T13:10:00+02:00</StartTime>
+						<EndTime>2020-10-01T16:00:00+02:00</EndTime>
+					</ValidityPeriod>
+					<PublicationWindow>
+						<StartTime>2020-10-01T13:10:00+02:00</StartTime>
+						<EndTime>2020-10-01T16:00:00+02:00</EndTime>
+					</PublicationWindow>
+					<AlertCause>policeActivity</AlertCause>
+					<Priority>2</Priority>
+					<!-- high -->
+					<Planned>false</Planned>
+					<Summary xml:lang="DE">Polizei-Einsatz an der S-Bahn-Station Sülldorf.</Summary>
+					<Description xml:lang="DE">Wegen des Polizei-Einsatzes an der Station Sülldorf 
+									kommt es zu einer Streckensperrung der S1 zwischen Blankenese - Wedel 
+									in beiden Richtungen. Vermutete Daueer ca. 3 Stunden. Es wird ein SEV 
+									eingerichtet, Dauer der Einrichtung ca. 30 Minuten. Danach fährt der 
+									SEV alle 10 Minuten für die Dauer der Streckensperrung.</Description>
+					<Affects>
+						<StopPlaces>
+							<AffectedStopPlace>
+								<StopPlaceRef>de:02000:81952</StopPlaceRef>
+								<PlaceName xml:lang="DE">Sülldorf</PlaceName>
+							</AffectedStopPlace>
+						</StopPlaces>
+					</Affects>
+					<Consequences>
+						<Consequence>
+							<!-- Initial bevore SEV takes place -->
+							<Period>
+								<StartTime>2020-10-01T13:10:00+02:00</StartTime>
+								<EndTime>2020-10-01T13:45:00+02:00</EndTime>
+							</Period>
+							<Condition>disruption</Condition>
+							<!-- it takes time until the SEV is ready -->
+							<Affects>
+								<Networks>
+									<AffectedNetwork>
+										<AffectedLine>
+											<AffectedOperator>
+												<OperatorShortName xml:lang="DE">S-Bahn</OperatorShortName>
+											</AffectedOperator>
+											<LineRef>ZVU-DB:S1_ZVU-DB_S-ZVU</LineRef>
+											<PublishedLineName xml:lang="DE">S1</PublishedLineName>
+											<StopPoints>
+												<!-- the portion between Iserbrook and Wedel is affected by the disruption -->
+												<AffectedStopPoint>
+													<StopPointRef>de:02000:81951</StopPointRef>
+													<StopPointName xml:lang="DE">Iserbrook</StopPointName>
+												</AffectedStopPoint>
+												<AffectedStopPoint>
+													<StopPointRef>de:02000:81952</StopPointRef>
+													<StopPointName xml:lang="DE">Sülldorf</StopPointName>
+												</AffectedStopPoint>
+												<AffectedStopPoint>
+													<StopPointRef>de:02000:81953</StopPointRef>
+													<StopPointName xml:lang="DE">Rissen</StopPointName>
+												</AffectedStopPoint>
+												<AffectedStopPoint>
+													<StopPointRef>de:01056:85950</StopPointRef>
+													<StopPointName xml:lang="DE">Wedel</StopPointName>
+												</AffectedStopPoint>
+											</StopPoints>
+										</AffectedLine>
+									</AffectedNetwork>
+								</Networks>
+							</Affects>
+							<Advice>
+								<Details xml:lang="DE">Es dauert vermutlich ca. 30 Minuten, bis der SEV bereit ist.</Details>
+								<Details xml:lang="DE">In dieser Zeit ist leider keine Beförderung möglich.</Details>
+							</Advice>
+							<Blocking>
+								<JourneyPlanner>true</JourneyPlanner>
+								<!-- handle disruption in Journey Planner -->
+								<RealTime>true</RealTime>
+								<!-- this blocks the real-time for the S1, which tells, 
+									 it would run all the way (but ends the trip in Blankenese) -->
+							</Blocking>
+						</Consequence>
+						<Consequence>
+							<Period>
+								<StartTime>2020-10-01T13:45:00+02:00</StartTime>
+								<EndTime>2020-10-01T16:00:00+02:00</EndTime>
+							</Period>
+							<Condition>predictableDelay</Condition>
+							<!-- special handling for the case the trip starts 
+									outside the disrupped portion but ends inside -->
+							<Affects>
+								<Networks>
+									<AffectedNetwork>
+										<AffectedLine>
+											<AffectedOperator>
+												<OperatorShortName xml:lang="DE">S-Bahn</OperatorShortName>
+											</AffectedOperator>
+											<LineRef>ZVU-DB:S1_ZVU-DB_S-ZVU</LineRef>
+											<PublishedLineName xml:lang="DE">S1</PublishedLineName>
+											<Direction>
+												<DirectionRef>6</DirectionRef>
+												<DirectionName>Wedel</DirectionName>
+											</Direction>
+											<StopPoints>
+												<AffectedStopPoint>
+													<StopPointRef>de:02000:81950</StopPointRef>
+													<StopPointName xml:lang="DE">Blankenese</StopPointName>
+												</AffectedStopPoint>
+												<AffectedStopPoint>
+													<StopPointRef>de:02000:81951</StopPointRef>
+													<StopPointName xml:lang="DE">Iserbrook</StopPointName>
+												</AffectedStopPoint>
+												<AffectedStopPoint>
+													<StopPointRef>de:02000:81952</StopPointRef>
+													<StopPointName xml:lang="DE">Sülldorf</StopPointName>
+												</AffectedStopPoint>
+												<AffectedStopPoint>
+													<StopPointRef>de:02000:81953</StopPointRef>
+													<StopPointName xml:lang="DE">Rissen</StopPointName>
+												</AffectedStopPoint>
+												<AffectedStopPoint>
+													<StopPointRef>de:01056:85950</StopPointRef>
+													<StopPointName xml:lang="DE">Wedel</StopPointName>
+												</AffectedStopPoint>
+											</StopPoints>
+										</AffectedLine>
+									</AffectedNetwork>
+								</Networks>
+							</Affects>
+							<Advice>
+								<Details xml:lang="DE">Der SEV hält an der regulären Bus-Haltestelle am jeweiligen S-Bahnhof.</Details>
+							</Advice>
+							<Blocking>
+								<JourneyPlanner>true</JourneyPlanner>
+								<!-- handle replacementRide (SEV) in Journey Planner -->
+								<RealTime>true</RealTime>
+								<!-- this blocks the real-time for the S1, which tells, 
+									 it would run all the way (but ends the trip in Blankenese) -->
+							</Blocking>
+							<PredictableDelays>
+								<PredictableDelay>
+									<AffectedStopPoint>
+										<StopPointRef>de:02000:81950</StopPointRef>
+										<StopPointName xml:lang="DE">Blankenese</StopPointName>
+									</AffectedStopPoint>
+									<DepartureTravelProlongation>PT10M</DepartureTravelProlongation>
+									<!-- 10 minutes for the change to SEV-->
+								</PredictableDelay>
+								<PredictableDelay>
+									<AffectedStopPoint>
+										<StopPointRef>de:02000:81951</StopPointRef>
+										<StopPointName xml:lang="DE">Iserbrook</StopPointName>
+									</AffectedStopPoint>
+									<ArrivalTravelProlongation>PT15M</ArrivalTravelProlongation>
+									<DepartureTravelProlongation>PT15M</DepartureTravelProlongation>
+								</PredictableDelay>
+								<PredictableDelay>
+									<AffectedStopPoint>
+										<StopPointRef>de:02000:81952</StopPointRef>
+										<StopPointName xml:lang="DE">Sülldorf</StopPointName>
+									</AffectedStopPoint>
+									<ArrivalTravelProlongation>PT20M</ArrivalTravelProlongation>
+									<DepartureTravelProlongation>PT20M</DepartureTravelProlongation>
+								</PredictableDelay>
+								<PredictableDelay>
+									<AffectedStopPoint>
+										<StopPointRef>de:02000:81953</StopPointRef>
+										<StopPointName xml:lang="DE">Rissen</StopPointName>
+									</AffectedStopPoint>
+									<ArrivalTravelProlongation>PT25M</ArrivalTravelProlongation>
+									<DepartureTravelProlongation>PT25M</DepartureTravelProlongation>
+								</PredictableDelay>
+								<PredictableDelay>
+									<AffectedStopPoint>
+										<StopPointRef>de:01056:85950</StopPointRef>
+										<StopPointName xml:lang="DE">Wedel</StopPointName>
+									</AffectedStopPoint>
+									<ArrivalTravelProlongation>PT30M</ArrivalTravelProlongation>
+                                    <DepartureTravelProlongation>PT40M</DepartureTravelProlongation>
+                                    <!-- 10 minutes for the change from SEV-->
+								</PredictableDelay>
+							</PredictableDelays>
+						</Consequence>
+						<Consequence>
+							<Period>
+								<StartTime>2020-10-01T13:45:00+02:00</StartTime>
+								<EndTime>2020-10-01T16:00:00+02:00</EndTime>
+							</Period>
+							<Condition>predictableDelay</Condition>
+							<!-- special handling for the case the trip starts 
+									inside the disrupped portion but ends outside -->
+							<Affects>
+								<Networks>
+									<AffectedNetwork>
+										<AffectedLine>
+											<AffectedOperator>
+												<OperatorShortName xml:lang="DE">S-Bahn</OperatorShortName>
+											</AffectedOperator>
+											<LineRef>ZVU-DB:S1_ZVU-DB_S-ZVU</LineRef>
+											<PublishedLineName xml:lang="DE">S1</PublishedLineName>
+											<Direction>
+												<DirectionRef>1</DirectionRef>
+												<DirectionName>Airport/Poppenbüttel</DirectionName>
+											</Direction>
+											<StopPoints>
+												<AffectedStopPoint>
+													<StopPointRef>de:02000:81950</StopPointRef>
+													<StopPointName xml:lang="DE">Blankenese</StopPointName>
+												</AffectedStopPoint>
+												<AffectedStopPoint>
+													<StopPointRef>de:02000:81951</StopPointRef>
+													<StopPointName xml:lang="DE">Iserbrook</StopPointName>
+												</AffectedStopPoint>
+												<AffectedStopPoint>
+													<StopPointRef>de:02000:81952</StopPointRef>
+													<StopPointName xml:lang="DE">Sülldorf</StopPointName>
+												</AffectedStopPoint>
+												<AffectedStopPoint>
+													<StopPointRef>de:02000:81953</StopPointRef>
+													<StopPointName xml:lang="DE">Rissen</StopPointName>
+												</AffectedStopPoint>
+												<AffectedStopPoint>
+													<StopPointRef>de:01056:85950</StopPointRef>
+													<StopPointName xml:lang="DE">Wedel</StopPointName>
+												</AffectedStopPoint>
+											</StopPoints>
+										</AffectedLine>
+									</AffectedNetwork>
+								</Networks>
+							</Affects>
+							<Advice>
+								<Details xml:lang="DE">Der SEV hält an der regulären Bus-Haltestelle am jeweiligen S-Bahnhof.</Details>
+							</Advice>
+							<Blocking>
+								<JourneyPlanner>true</JourneyPlanner>
+								<!-- handle replacementRide (SEV) in Journey Planner -->
+								<RealTime>true</RealTime>
+								<!-- this blocks the real-time for the S1, which tells, 
+									 it would run all the way (but ends the trip in Blankenese) -->
+							</Blocking>
+							<PredictableDelays>
+								<PredictableDelay>
+									<AffectedStopPoint>
+										<StopPointRef>de:02000:81950</StopPointRef>
+										<StopPointName xml:lang="DE">Blankenese</StopPointName>
+									</AffectedStopPoint>
+									<ArrivalTravelProlongation>PT30M</ArrivalTravelProlongation>
+									<DepartureTravelProlongation>PT40M</DepartureTravelProlongation>
+									<!-- 10 minutes more for the change from SEV-->
+								</PredictableDelay>
+								<PredictableDelay>
+									<AffectedStopPoint>
+										<StopPointRef>de:02000:81951</StopPointRef>
+										<StopPointName xml:lang="DE">Iserbrook</StopPointName>
+									</AffectedStopPoint>
+									<ArrivalTravelProlongation>PT25M</ArrivalTravelProlongation>
+									<DepartureTravelProlongation>PT25M</DepartureTravelProlongation>
+								</PredictableDelay>
+								<PredictableDelay>
+									<AffectedStopPoint>
+										<StopPointRef>de:02000:81952</StopPointRef>
+										<StopPointName xml:lang="DE">Sülldorf</StopPointName>
+									</AffectedStopPoint>
+									<ArrivalTravelProlongation>PT20M</ArrivalTravelProlongation>
+									<DepartureTravelProlongation>PT20M</DepartureTravelProlongation>
+								</PredictableDelay>
+								<PredictableDelay>
+									<AffectedStopPoint>
+										<StopPointRef>de:02000:81953</StopPointRef>
+										<StopPointName xml:lang="DE">Rissen</StopPointName>
+									</AffectedStopPoint>
+									<ArrivalTravelProlongation>PT15M</ArrivalTravelProlongation>
+									<DepartureTravelProlongation>PT15M</DepartureTravelProlongation>
+								</PredictableDelay>
+								<PredictableDelay>
+									<AffectedStopPoint>
+										<StopPointRef>de:01056:85950</StopPointRef>
+										<StopPointName xml:lang="DE">Wedel</StopPointName>
+									</AffectedStopPoint>
+									<DepartureTravelProlongation>PT10M</DepartureTravelProlongation>
+                                    <!-- 10 minutes for the change to SEV-->
+								</PredictableDelay>
+							</PredictableDelays>
+						</Consequence>
+					</Consequences>
+					<PublishingActions>
+						<PublishingAction>
+							<!-- for stop points display only -->
+							<PublishAtScope>
+								<ScopeType>line</ScopeType>
+								<Affects>
+									<Networks>
+										<AffectedNetwork>
+											<NetworkRef>S-Bahn</NetworkRef>
+											<AffectedLine>
+												<LineRef>ZVU-DB:S1_ZVU-DB_S-ZVU</LineRef>
+												<PublishedLineName xml:lang="DE">S1</PublishedLineName>
+												<Direction>
+													<DirectionRef>1</DirectionRef>
+													<DirectionName xml:lang="DE">Airport/Poppenbüttel</DirectionName>
+												</Direction>
+												<Direction>
+													<DirectionRef>6</DirectionRef>
+													<DirectionName xml:lang="DE">Wedel</DirectionName>
+												</Direction>
+											</AffectedLine>
+										</AffectedNetwork>
+									</Networks>
+								</Affects>
+							</PublishAtScope>
+							<PassengerInformationAction>
+								<PublicationWindow>
+									<StartTime>2020-10-01T13:10:00+02:00</StartTime>
+									<EndTime>2020-10-01T13:45:00+02:00</EndTime>
+								</PublicationWindow>
+								<ActionRef/>
+								<RecordedAtTime>2020-10-01T13:11:00+02:00</RecordedAtTime>
+								<SourceRef>S-Bahn_MES_Disponent</SourceRef>
+								<Perspective>stopPoint</Perspective>
+								<TextualContent>
+									<TextualContentSize>small</TextualContentSize>
+									<SummaryContent>
+										<SummaryText xml:lang="DE">S1 temporäre Streckensperrung Blankenese - Wedel</SummaryText>
+									</SummaryContent>
+								</TextualContent>
+							</PassengerInformationAction>
+							<PassengerInformationAction>
+								<PublicationWindow>
+									<StartTime>2020-10-01T13:45:00+02:00</StartTime>
+									<EndTime>2020-10-01T16:00:00+02:00</EndTime>
+								</PublicationWindow>
+								<ActionRef/>
+								<RecordedAtTime>2020-10-01T13:11:00+02:00</RecordedAtTime>
+								<SourceRef>S-Bahn_MES_Disponent</SourceRef>
+								<Perspective>stopPoint</Perspective>
+								<TextualContent>
+									<TextualContentSize>small</TextualContentSize>
+									<SummaryContent>
+										<SummaryText xml:lang="DE">S1 temporäre Streckensperrung Blankenese - Wedel</SummaryText>
+									</SummaryContent>
+									<DescriptionContent>
+										<DescriptionText xml:lang="DE">SEV ist eingerichtet, 
+													Verzögerung bis zu 30 Min.</DescriptionText>
+									</DescriptionContent>
+								</TextualContent>
+							</PassengerInformationAction>
+						</PublishingAction>
+						<PublishingAction>
+							<!-- Initial bevore SEV takes place plus general except journey planner-->
+							<PublishAtScope>
+								<ScopeType>line</ScopeType>
+								<Affects>
+									<Networks>
+										<AffectedNetwork>
+											<NetworkRef>S-Bahn</NetworkRef>
+											<AffectedLine>
+												<LineRef>ZVU-DB:S1_ZVU-DB_S-ZVU</LineRef>
+												<PublishedLineName xml:lang="DE">S1</PublishedLineName>
+												<Direction>
+													<DirectionRef>1</DirectionRef>
+													<DirectionName xml:lang="DE">Airport/Poppenbüttel</DirectionName>
+												</Direction>
+												<Direction>
+													<DirectionRef>6</DirectionRef>
+													<DirectionName xml:lang="DE">Wedel</DirectionName>
+												</Direction>
+												<StopPlaces>
+													<AffectedStopPlace>
+														<StopPlaceRef>de:02000:81950</StopPlaceRef>
+														<PlaceName xml:lang="DE">Blankenese</PlaceName>
+													</AffectedStopPlace>
+													<AffectedStopPlace>
+														<StopPlaceRef>de:02000:81951</StopPlaceRef>
+														<PlaceName xml:lang="DE">Iserbrook</PlaceName>
+													</AffectedStopPlace>
+													<AffectedStopPlace>
+														<StopPlaceRef>de:02000:81952</StopPlaceRef>
+														<PlaceName xml:lang="DE">Sülldorf</PlaceName>
+													</AffectedStopPlace>
+													<AffectedStopPlace>
+														<StopPlaceRef>de:02000:81953</StopPlaceRef>
+														<PlaceName xml:lang="DE">Rissen</PlaceName>
+													</AffectedStopPlace>
+													<AffectedStopPlace>
+														<StopPlaceRef>de:01056:85950</StopPlaceRef>
+														<PlaceName xml:lang="DE">Wedel</PlaceName>
+													</AffectedStopPlace>
+												</StopPlaces>
+											</AffectedLine>
+										</AffectedNetwork>
+									</Networks>
+								</Affects>
+							</PublishAtScope>
+							<PassengerInformationAction>
+								<PublicationWindow>
+									<StartTime>2020-10-01T13:10:00+02:00</StartTime>
+									<EndTime>2020-10-01T13:45:00+02:00</EndTime>
+								</PublicationWindow>
+								<ActionRef/>
+								<RecordedAtTime>2020-10-01T13:09:00+02:00</RecordedAtTime>
+								<SourceRef>S-Bahn_MES_Disponent</SourceRef>
+								<Perspective>general</Perspective>
+								<TextualContent>
+									<TextualContentSize>medium</TextualContentSize>
+									<SummaryContent>
+										<SummaryText xml:lang="DE">S1 Streckensperrung Blankenese - Wedel</SummaryText>
+									</SummaryContent>
+									<DescriptionContent>
+										<DescriptionText xml:lang="DE">Wegen eines Poilzei-Einsatzes ist 
+													derzeit keine Beförderung zwischen Blankenese und Wedel 
+													in beiden Richtungen möglich. SEV ist bestellt, 
+													dauert aber noch.</DescriptionText>
+									</DescriptionContent>
+								</TextualContent>
+								<TextualContent>
+									<TextualContentSize>small</TextualContentSize>
+									<SummaryContent>
+										<SummaryText xml:lang="DE">S1 Streckensperrung Blankenese - Wedel</SummaryText>
+									</SummaryContent>
+								</TextualContent>
+							</PassengerInformationAction>
+							<PassengerInformationAction>
+								<PublicationWindow>
+									<StartTime>2020-10-01T13:45:00+02:00</StartTime>
+									<EndTime>2020-10-01T16:00:00+02:00</EndTime>
+								</PublicationWindow>
+								<ActionRef/>
+								<RecordedAtTime>2020-10-01T13:09:00+02:00</RecordedAtTime>
+								<SourceRef>S-Bahn_MES_Disponent</SourceRef>
+								<Perspective>generalExceptJourneyPlanner</Perspective>
+								<TextualContent>
+									<TextualContentSize>medium</TextualContentSize>
+									<SummaryContent>
+										<SummaryText xml:lang="DE">S1 Streckensperrung Blankenese - Wedel</SummaryText>
+									</SummaryContent>
+									<DescriptionContent>
+										<DescriptionText xml:lang="DE">Wegen eines Poilzei-Einsatzes 
+													ist derzeit keine Beförderung zwischen Blankenese und Wedel 
+													in beiden Richtungen möglich. SEV ist eingerichtet, 
+													Verlängerung der Fahrzeit bis zu 30 Min.</DescriptionText>
+									</DescriptionContent>
+								</TextualContent>
+								<TextualContent>
+									<TextualContentSize>small</TextualContentSize>
+									<SummaryContent>
+										<SummaryText xml:lang="DE">S1 Streckensperrung Blankenese - Wedel</SummaryText>
+									</SummaryContent>
+									<DescriptionContent>
+										<DescriptionText xml:lang="DE">SEV ist eingerichtet, 
+													Verzögerung bis zu 30 Min.</DescriptionText>
+									</DescriptionContent>
+								</TextualContent>
+							</PassengerInformationAction>
+						</PublishingAction>
+						<PublishingAction>
+							<PublishAtScope>
+								<ScopeType>line</ScopeType>
+								<Affects>
+									<Networks>
+										<AffectedNetwork>
+											<NetworkRef>S-Bahn</NetworkRef>
+											<AffectedLine>
+												<LineRef>ZVU-DB:S1_ZVU-DB_S-ZVU</LineRef>
+												<PublishedLineName xml:lang="DE">S1</PublishedLineName>
+												<Direction>
+													<DirectionRef>6</DirectionRef>
+													<DirectionName xml:lang="DE">Wedel</DirectionName>
+												</Direction>
+												<StopPlaces>
+													<AffectedStopPlace>
+														<StopPlaceRef>de:02000:81950</StopPlaceRef>
+														<PlaceName xml:lang="DE">Blankenese</PlaceName>
+													</AffectedStopPlace>
+													<AffectedStopPlace>
+														<StopPlaceRef>de:02000:81951</StopPlaceRef>
+														<PlaceName xml:lang="DE">Iserbrook</PlaceName>
+													</AffectedStopPlace>
+													<AffectedStopPlace>
+														<StopPlaceRef>de:02000:81952</StopPlaceRef>
+														<PlaceName xml:lang="DE">Sülldorf</PlaceName>
+													</AffectedStopPlace>
+													<AffectedStopPlace>
+														<StopPlaceRef>de:02000:81953</StopPlaceRef>
+														<PlaceName xml:lang="DE">Rissen</PlaceName>
+													</AffectedStopPlace>
+													<AffectedStopPlace>
+														<StopPlaceRef>de:01056:85950</StopPlaceRef>
+														<PlaceName xml:lang="DE">Wedel</PlaceName>
+													</AffectedStopPlace>
+												</StopPlaces>
+											</AffectedLine>
+										</AffectedNetwork>
+									</Networks>
+								</Affects>
+							</PublishAtScope>
+							<PassengerInformationAction>
+								<PublicationWindow>
+									<StartTime>2020-10-01T13:45:00+02:00</StartTime>
+									<EndTime>2020-10-01T16:00:00+02:00</EndTime>
+								</PublicationWindow>
+								<ActionRef/>
+								<RecordedAtTime>2020-10-01T13:09:00+02:00</RecordedAtTime>
+								<SourceRef>S-Bahn_MES_Disponent</SourceRef>
+								<Perspective>journeyPlanner</Perspective>
+								<TextualContent>
+									<TextualContentSize>medium</TextualContentSize>
+									<SummaryContent>
+										<SummaryText xml:lang="DE">S1 Streckensperrung Blankenese - Wedel</SummaryText>
+									</SummaryContent>
+									<DescriptionContent>
+										<DescriptionText xml:lang="DE">Wegen eines Poilzei-Einsatzes 
+													ist derzeit keine Beförderung zwischen Blankenese und Wedel 
+													in beiden Richtungen möglich. SEV ist eingerichtet.
+										</DescriptionText>
+									</DescriptionContent>
+								</TextualContent>
+								<TextualContent>
+									<TextualContentSize>small</TextualContentSize>
+									<SummaryContent>
+										<SummaryText xml:lang="DE">S1 Streckensperrung Blankenese - Wedel</SummaryText>
+									</SummaryContent>
+									<DescriptionContent>
+										<DescriptionText xml:lang="DE">SEV ist eingerichtet, 
+													Verzögerung </DescriptionText>
+									</DescriptionContent>
+								</TextualContent>
+							</PassengerInformationAction>
+						</PublishingAction>
+						<PublishingAction>
+							<PublishAtScope>
+								<ScopeType>line</ScopeType>
+								<Affects>
+									<Networks>
+										<AffectedNetwork>
+											<NetworkRef>S-Bahn</NetworkRef>
+											<AffectedLine>
+												<LineRef>ZVU-DB:S1_ZVU-DB_S-ZVU</LineRef>
+												<PublishedLineName xml:lang="DE">S1</PublishedLineName>
+												<Direction>
+													<DirectionRef>1</DirectionRef>
+													<DirectionName xml:lang="DE">Airport/Poppenbüttel</DirectionName>
+												</Direction>
+												<StopPlaces>
+													<AffectedStopPlace>
+														<StopPlaceRef>de:02000:81950</StopPlaceRef>
+														<PlaceName xml:lang="DE">Blankenese</PlaceName>
+													</AffectedStopPlace>
+													<AffectedStopPlace>
+														<StopPlaceRef>de:02000:81951</StopPlaceRef>
+														<PlaceName xml:lang="DE">Iserbrook</PlaceName>
+													</AffectedStopPlace>
+													<AffectedStopPlace>
+														<StopPlaceRef>de:02000:81952</StopPlaceRef>
+														<PlaceName xml:lang="DE">Sülldorf</PlaceName>
+													</AffectedStopPlace>
+													<AffectedStopPlace>
+														<StopPlaceRef>de:02000:81953</StopPlaceRef>
+														<PlaceName xml:lang="DE">Rissen</PlaceName>
+													</AffectedStopPlace>
+													<AffectedStopPlace>
+														<StopPlaceRef>de:01056:85950</StopPlaceRef>
+														<PlaceName xml:lang="DE">Wedel</PlaceName>
+													</AffectedStopPlace>
+												</StopPlaces>
+											</AffectedLine>
+										</AffectedNetwork>
+									</Networks>
+								</Affects>
+							</PublishAtScope>
+							<PassengerInformationAction>
+								<PublicationWindow>
+									<StartTime>2020-10-01T13:45:00+02:00</StartTime>
+									<EndTime>2020-10-01T16:00:00+02:00</EndTime>
+								</PublicationWindow>
+								<ActionRef/>
+								<RecordedAtTime>2020-10-01T13:09:00+02:00</RecordedAtTime>
+								<SourceRef>S-Bahn_MES_Disponent</SourceRef>
+								<Perspective>journeyPlanner</Perspective>
+								<TextualContent>
+									<TextualContentSize>medium</TextualContentSize>
+									<SummaryContent>
+										<SummaryText xml:lang="DE">S1 Streckensperrung Blankenese - Wedel</SummaryText>
+									</SummaryContent>
+									<DescriptionContent>
+										<DescriptionText xml:lang="DE">Wegen eines Poilzei-Einsatzes 
+													ist derzeit keine Beförderung zwischen Blankenese und Wedel 
+													in beiden Richtungen möglich. SEV ist eingerichtet, 
+													Verlängerung der Fahrzeit </DescriptionText>
+									</DescriptionContent>
+								</TextualContent>
+								<TextualContent>
+									<TextualContentSize>small</TextualContentSize>
+									<SummaryContent>
+										<SummaryText xml:lang="DE">S1 Streckensperrung Blankenese - Wedel</SummaryText>
+									</SummaryContent>
+									<DescriptionContent>
+										<DescriptionText xml:lang="DE">SEV ist eingerichtet, 
+													Verzögerung </DescriptionText>
+									</DescriptionContent>
+								</TextualContent>
+							</PassengerInformationAction>
+						</PublishingAction>
+					</PublishingActions>
+				</PtSituationElement>
+			</Situations>
+		</SituationExchangeDelivery>
+	</ServiceDelivery>
+</Siri>

--- a/examples/hamburg_example/Use_Case_Abkehren1Seitig_S1_global_initial.xml
+++ b/examples/hamburg_example/Use_Case_Abkehren1Seitig_S1_global_initial.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Siri xmlns="http://www.siri.org.uk/siri" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.0" xsi:schemaLocation="http://www.siri.org.uk/siri ../../xsd/siri.xsd">
+	<ServiceDelivery>
+		<ResponseTimestamp>2020-10-01T13:10:00+02:00</ResponseTimestamp>
+		<ProducerRef>MES</ProducerRef>
+		<SituationExchangeDelivery version="2.0">
+			<ResponseTimestamp>2020-10-01T13:10:00+02:00</ResponseTimestamp>
+			<Situations>
+				<PtSituationElement>
+					<CreationTime>2020-10-01T13:10:00+02:00</CreationTime>
+					<ParticipantRef>S-Bahn-HH</ParticipantRef>
+					<SituationNumber>201001001</SituationNumber>
+					<Source>
+						<SourceType>web</SourceType>
+						<AgentReference>S-DB-HH</AgentReference>
+						<Name xml:lang="DE">S-Bahn MES Disponent</Name>
+						<TimeOfCommunication>2020-10-01T13:08:00+02:00</TimeOfCommunication>
+					</Source>
+					<Progress>published</Progress>
+					<ValidityPeriod>
+						<StartTime>2020-10-01T13:10:00+02:00</StartTime>
+						<EndTime>2020-10-01T16:00:00+02:00</EndTime>
+					</ValidityPeriod>
+					<PublicationWindow>
+						<StartTime>2020-10-01T13:10:00+02:00</StartTime>
+						<EndTime>2020-10-01T16:00:00+02:00</EndTime>
+					</PublicationWindow>
+					<AlertCause>personOnTheLine</AlertCause>
+					<Priority>2</Priority>	<!-- high -->
+					<Planned>false</Planned>
+					<Summary xml:lang="DE">Polizei-Einsatz in Sülldorf.</Summary>
+					<Description xml:lang="DE">Polizei-Einsatz an der 
+							S-Bahn-Haltestelle Sülldorf wegen spielender Kinder 
+							im Gleisbereich und herumstreunender Tiere. </Description>
+					<Affects>
+						<StopPlaces>
+							<AffectedStopPlace>
+								<StopPlaceRef>de:02000:81952</StopPlaceRef>
+								<PlaceName xml:lang="DE">Sülldorf</PlaceName>
+							</AffectedStopPlace>
+						</StopPlaces>
+					</Affects>
+				</PtSituationElement>
+			</Situations>
+		</SituationExchangeDelivery>
+	</ServiceDelivery>
+</Siri>

--- a/examples/hamburg_example/Use_Case_Abkehren1Seitig_S1_global_nur_Ausfall.xml
+++ b/examples/hamburg_example/Use_Case_Abkehren1Seitig_S1_global_nur_Ausfall.xml
@@ -1,0 +1,220 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Siri xmlns="http://www.siri.org.uk/siri" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.0" xsi:schemaLocation="http://www.siri.org.uk/siri ../../xsd/siri.xsd">
+	<ServiceDelivery>
+		<ResponseTimestamp>2020-10-01T13:12:00+02:00</ResponseTimestamp>
+		<ProducerRef>MES</ProducerRef>
+		<SituationExchangeDelivery version="2.0">
+			<ResponseTimestamp>2020-10-01T13:12:00+02:00</ResponseTimestamp>
+			<Situations>
+				<PtSituationElement>
+					<CreationTime>2020-10-01T13:12:00+02:00</CreationTime>
+					<ParticipantRef>S-Bahn-HH</ParticipantRef>
+					<SituationNumber>201001001</SituationNumber>
+					<Version>1</Version>
+					<Source>
+						<SourceType>web</SourceType>
+						<AgentReference>S-DB-HH</AgentReference>
+						<Name xml:lang="DE">S-Bahn MES Disponent</Name>
+						<TimeOfCommunication>2020-10-01T13:08:00+02:00</TimeOfCommunication>
+					</Source>
+					<VersionedAtTime>2020-10-01T13:12:00+02:00</VersionedAtTime>
+					<Progress>published</Progress>
+					<ValidityPeriod>
+						<StartTime>2020-10-01T13:10:00+02:00</StartTime>
+						<EndTime>2020-10-01T16:00:00+02:00</EndTime>
+					</ValidityPeriod>
+					<PublicationWindow>
+						<StartTime>2020-10-01T13:10:00+02:00</StartTime>
+						<EndTime>2020-10-01T16:00:00+02:00</EndTime>
+					</PublicationWindow>
+					<AlertCause>policeActivity</AlertCause>
+					<Priority>2</Priority>
+					<!-- high -->
+					<Planned>false</Planned>
+					<Summary xml:lang="DE">Polizei-Einsatz an der S-Bahn-Station Sülldorf.</Summary>
+					<Description xml:lang="DE">Wegen des Polizei-Einsatzes an der 
+							Station Sülldorf kommt es zu einer Streckensperrung der S1 
+							zwischen Blankenese - Wedel in beiden Richtungen. 
+							Vermutete Dauer ca. 3 Stunden.</Description>
+					<Affects>
+						<StopPlaces>
+							<AffectedStopPlace>
+								<StopPlaceRef>de:02000:81952</StopPlaceRef>
+								<PlaceName xml:lang="DE">Sülldorf</PlaceName>
+							</AffectedStopPlace>
+						</StopPlaces>
+					</Affects>
+					<Consequences>
+						<Consequence>
+							<!-- disruption between Blankenese and Wedel -->
+							<Period>
+								<StartTime>2020-10-01T13:10:00+02:00</StartTime>
+								<EndTime>2020-10-01T16:00:00+02:00</EndTime>
+							</Period>
+							<Condition>disruption</Condition>
+							<!-- at this time, all trips are disabled on the 
+								 portion between Blankenese and Wedel -->
+							<Affects>
+								<Networks>
+									<AffectedNetwork>
+										<AffectedLine>
+											<AffectedOperator>
+												<OperatorShortName xml:lang="DE">S-Bahn</OperatorShortName>
+											</AffectedOperator>
+											<LineRef>ZVU-DB:S1_ZVU-DB_S-ZVU</LineRef>
+											<PublishedLineName xml:lang="DE">S1</PublishedLineName>
+											<StopPoints>
+												<!-- the portion between Iserbrook and Wedel is affected by the disruption -->
+												<AffectedStopPoint>
+													<StopPointRef>de:02000:81951</StopPointRef>
+													<StopPointName xml:lang="DE">Iserbrook</StopPointName>
+												</AffectedStopPoint>
+												<AffectedStopPoint>
+													<StopPointRef>de:02000:81952</StopPointRef>
+													<StopPointName xml:lang="DE">Sülldorf</StopPointName>
+												</AffectedStopPoint>
+												<AffectedStopPoint>
+													<StopPointRef>de:02000:81953</StopPointRef>
+													<StopPointName xml:lang="DE">Rissen</StopPointName>
+												</AffectedStopPoint>
+												<AffectedStopPoint>
+													<StopPointRef>de:01056:85950</StopPointRef>
+													<StopPointName xml:lang="DE">Wedel</StopPointName>
+												</AffectedStopPoint>
+											</StopPoints>
+										</AffectedLine>
+									</AffectedNetwork>
+								</Networks>
+							</Affects>
+							<Blocking>
+								<JourneyPlanner>true</JourneyPlanner>
+								<!-- handle no-service in Journey Planner -->
+								<RealTime>true</RealTime>
+								<!-- this blocks the real-time for the S1, which tells, 
+									 it would run all the way (but ends the trip in Blankenese) -->
+							</Blocking>
+						</Consequence>
+					</Consequences>
+					<PublishingActions>
+						<PublishingAction>
+							<!-- for Perspective "general" -->
+							<PublishAtScope>
+								<ScopeType>line</ScopeType>
+								<Affects>
+									<Networks>
+										<AffectedNetwork>
+											<NetworkRef>S-Bahn</NetworkRef>
+											<AffectedLine>
+												<LineRef>ZVU-DB:S1_ZVU-DB_S-ZVU</LineRef>
+												<PublishedLineName xml:lang="DE">S1</PublishedLineName>
+												<Direction>
+													<DirectionRef>1</DirectionRef>
+													<DirectionName xml:lang="DE">Airport/Poppenbüttel</DirectionName>
+												</Direction>
+												<Direction>
+													<DirectionRef>6</DirectionRef>
+													<DirectionName xml:lang="DE">Wedel</DirectionName>
+												</Direction>
+												<StopPlaces>
+													<AffectedStopPlace>
+														<StopPlaceRef>de:02000:81950</StopPlaceRef>
+														<PlaceName xml:lang="DE">Blankenese</PlaceName>
+													</AffectedStopPlace>
+													<AffectedStopPlace>
+														<StopPlaceRef>de:02000:81951</StopPlaceRef>
+														<PlaceName xml:lang="DE">Iserbrook</PlaceName>
+													</AffectedStopPlace>
+													<AffectedStopPlace>
+														<StopPlaceRef>de:02000:81952</StopPlaceRef>
+														<PlaceName xml:lang="DE">Sülldorf</PlaceName>
+													</AffectedStopPlace>
+													<AffectedStopPlace>
+														<StopPlaceRef>de:02000:81953</StopPlaceRef>
+														<PlaceName xml:lang="DE">Rissen</PlaceName>
+													</AffectedStopPlace>
+													<AffectedStopPlace>
+														<StopPlaceRef>de:01056:85950</StopPlaceRef>
+														<PlaceName xml:lang="DE">Wedel</PlaceName>
+													</AffectedStopPlace>
+												</StopPlaces>
+											</AffectedLine>
+										</AffectedNetwork>
+									</Networks>
+								</Affects>
+							</PublishAtScope>
+							<PassengerInformationAction>
+								<PublicationWindow>
+									<StartTime>2020-10-01T13:10:00+02:00</StartTime>
+									<EndTime>2020-10-01T16:00:00+02:00</EndTime>
+								</PublicationWindow>
+								<ActionRef/>
+								<RecordedAtTime>2020-10-01T13:11:00+02:00</RecordedAtTime>
+								<SourceRef>S-Bahn_MES_Disponent</SourceRef>
+								<Perspective>general</Perspective>
+								<TextualContent>
+									<TextualContentSize>medium</TextualContentSize>
+									<SummaryContent>
+										<SummaryText xml:lang="DE">S1 Streckensperrung Blankenese - Wedel</SummaryText>
+									</SummaryContent>
+									<DescriptionContent>
+										<DescriptionText xml:lang="DE">Wegen eines Poilzei-Einsatzes ist 
+													derzeit keine Beförderung zwischen Blankenese und Wedel 
+													in beiden Richtungen möglich.</DescriptionText>
+									</DescriptionContent>
+								</TextualContent>
+								<TextualContent>
+									<TextualContentSize>small</TextualContentSize>
+									<SummaryContent>
+										<SummaryText xml:lang="DE">S1 Streckensperrung Blankenese - Wedel</SummaryText>
+									</SummaryContent>
+								</TextualContent>
+							</PassengerInformationAction>
+						</PublishingAction>
+						<PublishingAction>
+							<!-- for stop points display only -->
+							<PublishAtScope>
+								<ScopeType>line</ScopeType>
+								<Affects>
+									<Networks>
+										<AffectedNetwork>
+											<NetworkRef>S-Bahn</NetworkRef>
+											<AffectedLine>
+												<LineRef>ZVU-DB:S1_ZVU-DB_S-ZVU</LineRef>
+												<PublishedLineName xml:lang="DE">S1</PublishedLineName>
+												<Direction>
+													<DirectionRef>1</DirectionRef>
+													<DirectionName xml:lang="DE">Airport/Poppenbüttel</DirectionName>
+												</Direction>
+												<Direction>
+													<DirectionRef>6</DirectionRef>
+													<DirectionName xml:lang="DE">Wedel</DirectionName>
+												</Direction>
+											</AffectedLine>
+										</AffectedNetwork>
+									</Networks>
+								</Affects>
+							</PublishAtScope>
+							<PassengerInformationAction>
+								<PublicationWindow>
+									<StartTime>2020-10-01T13:10:00+02:00</StartTime>
+									<EndTime>2020-10-01T16:00:00+02:00</EndTime>
+								</PublicationWindow>
+								<ActionRef/>
+								<RecordedAtTime>2020-10-01T13:11:00+02:00</RecordedAtTime>
+								<SourceRef>S-Bahn_MES_Disponent</SourceRef>
+								<Perspective>stopPoint</Perspective>
+								<TextualContent>
+									<TextualContentSize>small</TextualContentSize>
+									<SummaryContent>
+										<SummaryText xml:lang="DE">
+											S1 temporäre Streckensperrung Blankenese - Wedel</SummaryText>
+									</SummaryContent>
+								</TextualContent>
+							</PassengerInformationAction>
+						</PublishingAction>
+					</PublishingActions>
+				</PtSituationElement>
+			</Situations>
+		</SituationExchangeDelivery>
+	</ServiceDelivery>
+</Siri>

--- a/examples/hamburg_example/Use_Case_Abkehren2Seitig_U1_global_SEV.xml
+++ b/examples/hamburg_example/Use_Case_Abkehren2Seitig_U1_global_SEV.xml
@@ -1,0 +1,599 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Siri xmlns="http://www.siri.org.uk/siri" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.0" xsi:schemaLocation="http://www.siri.org.uk/siri ../../xsd/siri.xsd">
+	<ServiceDelivery>
+		<ResponseTimestamp>2020-10-01T13:10:00+02:00</ResponseTimestamp>
+		<ProducerRef>MES</ProducerRef>
+		<SituationExchangeDelivery version="2.0">
+			<ResponseTimestamp>2020-10-01T13:10:00+02:00</ResponseTimestamp>
+			<Situations>
+				<PtSituationElement>
+					<CreationTime>2020-10-01T13:20:00+02:00</CreationTime>
+					<ParticipantRef>U-Bahn-HH</ParticipantRef>
+					<SituationNumber>201001002</SituationNumber>
+					<Version>2</Version>
+					<Source>
+						<SourceType>web</SourceType>
+						<AgentReference>Hochbahn_U</AgentReference>
+						<Name xml:lang="DE">Hochbahn U MES Disponent</Name>
+						<TimeOfCommunication>2020-10-01T13:08:00+02:00</TimeOfCommunication>
+					</Source>
+					<VersionedAtTime>2020-10-01T13:20:00+02:00</VersionedAtTime>
+					<Progress>published</Progress>
+					<ValidityPeriod>
+						<StartTime>2020-10-01T13:10:00+02:00</StartTime>
+						<EndTime>2020-10-01T16:00:00+02:00</EndTime>
+					</ValidityPeriod>
+					<PublicationWindow>
+						<StartTime>2020-10-01T13:10:00+02:00</StartTime>
+						<EndTime>2020-10-01T16:00:00+02:00</EndTime>
+					</PublicationWindow>
+					<AlertCause>policeActivity</AlertCause>
+					<Priority>2</Priority>
+					<!-- high -->
+					<Planned>false</Planned>
+					<Summary xml:lang="DE">Polizei-Einsatz an der U-Bahn-Station Steinstraße.</Summary>
+					<Description xml:lang="DE">Wegen des Polizei-Einsatzes an der Station Steinstraße kommt es 
+									zu einer Streckensperrung der U1 zwischen Hauptbahnhof Süd und Jungfernstieg 
+									in beiden Richtungen. Vermutete Dauer ca. 3 Stunden. Es wird ein SEV 
+									eingerichtet, Dauer der Einrichtung ca. 25 Minuten. Danach fährt der 
+									SEV alle 10 Minuten für die Dauer der Streckensperrung.</Description>
+					<Affects>
+						<StopPlaces>
+							<AffectedStopPlace>
+								<StopPlaceRef>de:02000:10907</StopPlaceRef>
+								<PlaceName xml:lang="DE">Steinstraße</PlaceName>
+							</AffectedStopPlace>
+						</StopPlaces>
+					</Affects>
+					<Consequences>
+						<Consequence>		<!-- Initial bevore SEV takes place -->
+							<Period>
+								<StartTime>2020-10-01T13:10:00+02:00</StartTime>
+								<EndTime>2020-10-01T13:45:00+02:00</EndTime>
+							</Period>
+							<Condition>disruption</Condition>
+							<!-- it takes time until the SEV is ready -->
+							<Affects>
+								<Networks>
+									<AffectedNetwork>
+										<AffectedLine>
+											<AffectedOperator>
+												<OperatorShortName xml:lang="DE">HHA-U</OperatorShortName>
+											</AffectedOperator>
+											<LineRef>HHA-U:U1_HHA-U</LineRef>
+											<PublishedLineName xml:lang="DE">U1</PublishedLineName>
+											<StopPoints>
+												<!-- the portion between Steinstraße and Meßberg is affected by the disruption -->
+												<AffectedStopPoint>
+													<StopPointRef>de:02000:10907</StopPointRef>
+													<StopPointName xml:lang="DE">Steinstraße</StopPointName>
+												</AffectedStopPoint>
+												<AffectedStopPoint>
+													<StopPointRef>de:02000:11903</StopPointRef>
+													<StopPointName xml:lang="DE">Meßberg</StopPointName>
+												</AffectedStopPoint>
+											</StopPoints>
+										</AffectedLine>
+									</AffectedNetwork>
+								</Networks>
+							</Affects>
+							<Advice>
+								<Details xml:lang="DE">Es dauert vermutlich ca. 25 Minuten, bis der SEV bereit ist.</Details>
+								<Details xml:lang="DE">In dieser Zeit ist leider keine Beförderung möglich.</Details>
+							</Advice>
+							<Blocking>
+								<JourneyPlanner>true</JourneyPlanner>
+								<!-- handle disruption in Journey Planner -->
+								<RealTime>true</RealTime>
+								<!-- this blocks the real-time for the U1, which tells, 
+									 it would run all the way (but ends the trip in Hauptbahnhof Süd) -->
+							</Blocking>
+						</Consequence>
+						<Consequence>
+							<!-- FORMER matchingInto SEV Ri 6 -->
+							<Period>
+								<StartTime>2020-10-01T13:45:00+02:00</StartTime>
+								<EndTime>2020-10-01T16:00:00+02:00</EndTime>
+							</Period>
+
+							<!-- Simulation of SEV by a DELAY for the SEV-area -->
+							<Condition>predictableDelay</Condition>
+							<!-- special handling for the case the trip starts 
+									outside the disrupped portion but ends inside -->
+							<Affects>
+								<Networks>
+									<AffectedNetwork>
+										<AffectedLine>
+											<AffectedOperator>
+												<OperatorShortName xml:lang="DE">HHA-U</OperatorShortName>
+											</AffectedOperator>
+											<LineRef>HHA-U:U1_HHA-U</LineRef>
+											<PublishedLineName xml:lang="DE">U1</PublishedLineName>
+											<Direction>
+												<DirectionRef>6</DirectionRef>
+												<DirectionName>Norderstedt Mitte</DirectionName>
+											</Direction>
+											<StopPoints>
+												<!-- the portion between Hauptbahnhof Süd and Jungfernstieg is affected by the delay  -->
+												<AffectedStopPoint>
+													<StopPointRef>de:02000:10906</StopPointRef>
+													<StopPointName xml:lang="DE">Hauptbahnhof Süd</StopPointName>
+												</AffectedStopPoint>
+												<AffectedStopPoint>
+													<StopPointRef>de:02000:10907</StopPointRef>
+													<StopPointName xml:lang="DE">Steinstraße</StopPointName>
+												</AffectedStopPoint>
+												<AffectedStopPoint>
+													<StopPointRef>de:02000:11903</StopPointRef>
+													<StopPointName xml:lang="DE">Meßberg</StopPointName>
+												</AffectedStopPoint>
+												<AffectedStopPoint>
+													<StopPointRef>de:02000:11950</StopPointRef>
+													<StopPointName xml:lang="DE">Jungfernstieg</StopPointName>
+												</AffectedStopPoint>
+											</StopPoints>
+										</AffectedLine>
+									</AffectedNetwork>
+								</Networks>
+							</Affects>
+							<Advice>
+								<Details xml:lang="DE">Der SEV hält an der regulären Bus-Haltestelle am jeweiligen U-Bahnhof.</Details>
+							</Advice>
+							<Blocking>
+								<JourneyPlanner>true</JourneyPlanner>
+								<!-- handle predictableDelay (SEV) in Journey Planner -->
+								<RealTime>true</RealTime>
+								<!-- this blocks the real-time for the U1, which tells, 
+									 it would run all the way (but ends the trip in Hauptbahnhof Süd) -->
+							</Blocking>
+							<PredictableDelays>
+								<PredictableDelay>
+									<AffectedStopPoint>
+										<StopPointRef>de:02000:10906</StopPointRef>
+										<StopPointName xml:lang="DE">Hauptbahnhof Süd</StopPointName>
+									</AffectedStopPoint>
+									<DepartureTravelProlongation>PT10M</DepartureTravelProlongation>
+									<!-- 10 minutes for the change to SEV-->
+								</PredictableDelay>
+								<PredictableDelay>
+									<AffectedStopPoint>
+										<StopPointRef>de:02000:10907</StopPointRef>
+										<StopPointName xml:lang="DE">Steinstraße</StopPointName>
+									</AffectedStopPoint>
+									<ArrivalTravelProlongation>PT15M</ArrivalTravelProlongation>
+									<DepartureTravelProlongation>PT15M</DepartureTravelProlongation>
+								</PredictableDelay>
+								<PredictableDelay>
+									<AffectedStopPoint>
+										<StopPointRef>de:02000:11903</StopPointRef>
+										<StopPointName xml:lang="DE">Meßberg</StopPointName>
+									</AffectedStopPoint>
+									<ArrivalTravelProlongation>PT20M</ArrivalTravelProlongation>
+									<DepartureTravelProlongation>PT20M</DepartureTravelProlongation>
+								</PredictableDelay>
+								<PredictableDelay>
+									<AffectedStopPoint>
+										<StopPointRef>de:02000:11950</StopPointRef>
+										<StopPointName xml:lang="DE">Jungfernstieg</StopPointName>
+									</AffectedStopPoint>
+									<DepartureTravelProlongation>PT30M</DepartureTravelProlongation>
+									<!-- 10 minutes for the change to SEV-->
+								</PredictableDelay>
+							</PredictableDelays>
+						</Consequence>
+						<Consequence>
+							<!-- FORMER matchingInto SEV Ri 1 -->
+							<Period>
+								<StartTime>2020-10-01T13:45:00+02:00</StartTime>
+								<EndTime>2020-10-01T16:00:00+02:00</EndTime>
+							</Period>
+							<Condition>predictableDelay</Condition>
+							<Affects>
+								<Networks>
+									<AffectedNetwork>
+										<AffectedLine>
+											<AffectedOperator>
+												<OperatorShortName xml:lang="DE">HHA-U</OperatorShortName>
+											</AffectedOperator>
+											<LineRef>HHA-U:U1_HHA-U</LineRef>
+											<PublishedLineName xml:lang="DE">U1</PublishedLineName>
+											<Direction>
+												<DirectionRef>1</DirectionRef>
+												<DirectionName>Großhansdorf</DirectionName>
+											</Direction>
+											<Direction>
+												<DirectionRef>1</DirectionRef>
+												<DirectionName>Ohlstedt</DirectionName>
+											</Direction>
+											<StopPoints>
+												<!-- the portion between Hauptbahnhof Süd and Jungfernstieg is affected by the delay  -->
+												<AffectedStopPoint>
+													<StopPointRef>de:02000:11950</StopPointRef>
+													<StopPointName xml:lang="DE">Jungfernstieg</StopPointName>
+												</AffectedStopPoint>
+												<AffectedStopPoint>
+													<StopPointRef>de:02000:11903</StopPointRef>
+													<StopPointName xml:lang="DE">Meßberg</StopPointName>
+												</AffectedStopPoint>
+												<AffectedStopPoint>
+													<StopPointRef>de:02000:10907</StopPointRef>
+													<StopPointName xml:lang="DE">Steinstraße</StopPointName>
+												</AffectedStopPoint>
+												<AffectedStopPoint>
+													<StopPointRef>de:02000:10906</StopPointRef>
+													<StopPointName xml:lang="DE">Hauptbahnhof Süd</StopPointName>
+												</AffectedStopPoint>
+											</StopPoints>
+										</AffectedLine>
+									</AffectedNetwork>
+								</Networks>
+							</Affects>
+							<Advice>
+								<Details xml:lang="DE">Der SEV hält an der regulären Bus-Haltestelle am jeweiligen U-Bahnhof.</Details>
+							</Advice>
+							<Blocking>
+								<JourneyPlanner>true</JourneyPlanner>
+								<!-- handle replacementRide (SEV) in Journey Planner -->
+								<RealTime>true</RealTime>
+								<!-- this blocks the real-time for the U1, which tells, 
+									 it would run all the way (but ends the trip in Hauptbahnhof Süd) -->
+							</Blocking>
+							<PredictableDelays>
+								<PredictableDelay>
+									<AffectedStopPoint>
+										<StopPointRef>de:02000:11950</StopPointRef>
+										<StopPointName xml:lang="DE">Jungfernstieg</StopPointName>
+									</AffectedStopPoint>
+									<DepartureTravelProlongation>PT10M</DepartureTravelProlongation>
+									<!-- 10 minutes for the change to SEV-->
+								</PredictableDelay>
+								<PredictableDelay>
+									<AffectedStopPoint>
+										<StopPointRef>de:02000:11903</StopPointRef>
+										<StopPointName xml:lang="DE">Meßberg</StopPointName>
+									</AffectedStopPoint>
+									<ArrivalTravelProlongation>PT15M</ArrivalTravelProlongation>
+									<DepartureTravelProlongation>PT15M</DepartureTravelProlongation>
+								</PredictableDelay>
+								<PredictableDelay>
+									<AffectedStopPoint>
+										<StopPointRef>de:02000:10907</StopPointRef>
+										<StopPointName xml:lang="DE">Steinstraße</StopPointName>
+									</AffectedStopPoint>
+									<ArrivalTravelProlongation>PT20M</ArrivalTravelProlongation>
+									<DepartureTravelProlongation>PT20M</DepartureTravelProlongation>
+								</PredictableDelay>
+								<PredictableDelay>
+									<AffectedStopPoint>
+										<StopPointRef>de:02000:10906</StopPointRef>
+										<StopPointName xml:lang="DE">Hauptbahnhof Süd</StopPointName>
+									</AffectedStopPoint>
+									<DepartureTravelProlongation>PT30M</DepartureTravelProlongation>
+									<!-- 10 minutes for the change to SEV-->
+								</PredictableDelay>
+							</PredictableDelays>
+						</Consequence>
+					</Consequences>
+					<PublishingActions>
+						<PublishingAction>	<!-- for stop points display only -->
+							<PublishAtScope>
+								<ScopeType>line</ScopeType>
+								<Affects>
+									<Networks>
+										<AffectedNetwork>
+											<NetworkRef>HHA-U</NetworkRef>
+											<AffectedLine>
+												<LineRef>HHA-U:U1_HHA-U</LineRef>
+												<PublishedLineName xml:lang="DE">U1</PublishedLineName>
+												<!-- in both directions  -->
+												<Direction>
+													<DirectionRef>1</DirectionRef>
+													<DirectionName>Großhansdorf</DirectionName>
+												</Direction>
+												<Direction>
+													<DirectionRef>1</DirectionRef>
+													<DirectionName>Ohlstedt</DirectionName>
+												</Direction>
+												<Direction>
+													<DirectionRef>6</DirectionRef>
+													<DirectionName>Norderstedt Mitte</DirectionName>
+												</Direction>
+											</AffectedLine>
+										</AffectedNetwork>
+									</Networks>
+								</Affects>
+							</PublishAtScope>
+							<PassengerInformationAction>
+								<PublicationWindow>
+									<StartTime>2020-10-01T13:10:00+02:00</StartTime>
+									<EndTime>2020-10-01T13:45:00+02:00</EndTime>
+								</PublicationWindow>
+								<ActionRef/>
+								<RecordedAtTime>2020-10-01T13:11:00+02:00</RecordedAtTime>
+								<SourceRef>Hochbahn_U_MES_Disponent</SourceRef>
+								<Perspective>stopPoint</Perspective>
+								<TextualContent>
+									<TextualContentSize>small</TextualContentSize>
+									<SummaryContent>
+										<SummaryText xml:lang="DE">U1 temporäre Streckensperrung Hauptbahnhof Süd - Jungfernstieg</SummaryText>
+									</SummaryContent>
+								</TextualContent>
+							</PassengerInformationAction>
+							<PassengerInformationAction>
+								<PublicationWindow>
+									<StartTime>2020-10-01T13:45:00+02:00</StartTime>
+									<EndTime>2020-10-01T16:00:00+02:00</EndTime>
+								</PublicationWindow>
+								<ActionRef/>
+								<RecordedAtTime>2020-10-01T13:11:00+02:00</RecordedAtTime>
+								<SourceRef>Hochbahn_U_MES_Disponent</SourceRef>
+								<Perspective>stopPoint</Perspective>
+								<TextualContent>
+									<TextualContentSize>small</TextualContentSize>
+									<SummaryContent>
+										<SummaryText xml:lang="DE">U1 temporäre Streckensperrung Hauptbahnhof Süd - Jungfernstieg</SummaryText>
+									</SummaryContent>
+									<DescriptionContent>
+										<DescriptionText xml:lang="DE">SEV ist eingerichtet, 
+													Verzögerung bis zu 25 Min.</DescriptionText>
+									</DescriptionContent>
+								</TextualContent>
+							</PassengerInformationAction>
+						</PublishingAction>
+						<PublishingAction>	<!-- Initial bevore SEV takes place plus general except journey planner-->
+							<PublishAtScope>
+								<ScopeType>line</ScopeType>
+								<Affects>
+									<Networks>
+										<AffectedNetwork>
+											<NetworkRef>HHA-U</NetworkRef>
+											<AffectedLine>
+												<LineRef>HHA-U:U1_HHA-U</LineRef>
+												<PublishedLineName xml:lang="DE">U1</PublishedLineName>
+												<!-- in both directions  -->
+												<Direction>
+													<DirectionRef>1</DirectionRef>
+													<DirectionName>Großhansdorf</DirectionName>
+												</Direction>
+												<Direction>
+													<DirectionRef>1</DirectionRef>
+													<DirectionName>Ohlstedt</DirectionName>
+												</Direction>
+												<Direction>
+													<DirectionRef>6</DirectionRef>
+													<DirectionName>Norderstedt Mitte</DirectionName>
+												</Direction>
+												<StopPlaces>
+													<AffectedStopPlace>
+														<StopPlaceRef>de:02000:10906</StopPlaceRef>
+														<PlaceName xml:lang="DE">Hauptbahnhof Süd</PlaceName>
+													</AffectedStopPlace>
+													<AffectedStopPlace>
+														<StopPlaceRef>de:02000:10907</StopPlaceRef>
+														<PlaceName xml:lang="DE">Steinstraße</PlaceName>
+													</AffectedStopPlace>
+													<AffectedStopPlace>
+														<StopPlaceRef>de:02000:11903</StopPlaceRef>
+														<PlaceName xml:lang="DE">Meßberg</PlaceName>
+													</AffectedStopPlace>
+													<AffectedStopPlace>
+														<StopPlaceRef>de:02000:11950</StopPlaceRef>
+														<PlaceName xml:lang="DE">Jungfernstieg</PlaceName>
+													</AffectedStopPlace>
+												</StopPlaces>
+											</AffectedLine>
+										</AffectedNetwork>
+									</Networks>
+								</Affects>
+							</PublishAtScope>
+							<PassengerInformationAction>
+								<PublicationWindow>
+									<StartTime>2020-10-01T13:10:00+02:00</StartTime>
+									<EndTime>2020-10-01T13:45:00+02:00</EndTime>
+								</PublicationWindow>
+								<ActionRef/>
+								<RecordedAtTime>2020-10-01T13:09:00+02:00</RecordedAtTime>
+								<SourceRef>Hochbahn_U_MES_Disponent</SourceRef>
+								<Perspective>general</Perspective>
+								<TextualContent>
+									<TextualContentSize>medium</TextualContentSize>
+									<SummaryContent>
+										<SummaryText xml:lang="DE">U1 Streckensperrung Hauptbahnhof Süd - Jungfernstieg</SummaryText>
+									</SummaryContent>
+									<DescriptionContent>
+										<DescriptionText xml:lang="DE">Wegen eines Poilzei-Einsatzes ist 
+													derzeit keine Beförderung zwischen Hauptbahnhof Süd und Jungfernstieg 
+													in beiden Richtungen möglich. SEV ist bestellt, 
+													dauert aber noch.</DescriptionText>
+									</DescriptionContent>
+								</TextualContent>
+								<TextualContent>
+									<TextualContentSize>small</TextualContentSize>
+									<SummaryContent>
+										<SummaryText xml:lang="DE">U1 Streckensperrung Hauptbahnhof Süd - Jungfernstieg</SummaryText>
+									</SummaryContent>
+								</TextualContent>
+							</PassengerInformationAction>
+							<PassengerInformationAction>
+								<PublicationWindow>
+									<StartTime>2020-10-01T13:45:00+02:00</StartTime>
+									<EndTime>2020-10-01T16:00:00+02:00</EndTime>
+								</PublicationWindow>
+								<ActionRef/>
+								<RecordedAtTime>2020-10-01T13:09:00+02:00</RecordedAtTime>
+								<SourceRef>Hochbahn_U_MES_Disponent</SourceRef>
+								<Perspective>generalExceptJourneyPlanner</Perspective>
+								<TextualContent>
+									<TextualContentSize>medium</TextualContentSize>
+									<SummaryContent>
+										<SummaryText xml:lang="DE">U1 Streckensperrung Hauptbahnhof Süd - Jungfernstieg</SummaryText>
+									</SummaryContent>
+									<DescriptionContent>
+										<DescriptionText xml:lang="DE">Wegen eines Poilzei-Einsatzes 
+													ist derzeit keine Beförderung zwischen Hauptbahnhof Süd und Jungfernstieg 
+													in beiden Richtungen möglich. SEV ist eingerichtet, 
+													Verlängerung der Fahrzeit bis zu 25 Min.</DescriptionText>
+									</DescriptionContent>
+								</TextualContent>
+								<TextualContent>
+									<TextualContentSize>small</TextualContentSize>
+									<SummaryContent>
+										<SummaryText xml:lang="DE">U1 Streckensperrung Hauptbahnhof Süd - Jungfernstieg</SummaryText>
+									</SummaryContent>
+									<DescriptionContent>
+										<DescriptionText xml:lang="DE">SEV ist eingerichtet, 
+													Verzögerung bis zu 25 Min.</DescriptionText>
+									</DescriptionContent>
+								</TextualContent>
+							</PassengerInformationAction>
+						</PublishingAction>
+						<PublishingAction>
+							<PublishAtScope>
+								<ScopeType>line</ScopeType>
+								<Affects>
+									<Networks>
+										<AffectedNetwork>
+											<NetworkRef>HHA-U</NetworkRef>
+											<AffectedLine>
+												<LineRef>HHA-U:U1_HHA-U</LineRef>
+												<PublishedLineName xml:lang="DE">U1</PublishedLineName>
+												<Direction>
+													<DirectionRef>6</DirectionRef>
+													<DirectionName>Norderstedt Mitte</DirectionName>
+												</Direction>
+												<StopPlaces>
+													<AffectedStopPlace>
+														<StopPlaceRef>de:02000:10906</StopPlaceRef>
+														<PlaceName xml:lang="DE">Hauptbahnhof Süd</PlaceName>
+													</AffectedStopPlace>
+													<AffectedStopPlace>
+														<StopPlaceRef>de:02000:10907</StopPlaceRef>
+														<PlaceName xml:lang="DE">Steinstraße</PlaceName>
+													</AffectedStopPlace>
+													<AffectedStopPlace>
+														<StopPlaceRef>de:02000:11903</StopPlaceRef>
+														<PlaceName xml:lang="DE">Meßberg</PlaceName>
+													</AffectedStopPlace>
+													<AffectedStopPlace>
+														<StopPlaceRef>de:02000:11950</StopPlaceRef>
+														<PlaceName xml:lang="DE">Jungfernstieg</PlaceName>
+													</AffectedStopPlace>
+												</StopPlaces>
+											</AffectedLine>
+										</AffectedNetwork>
+									</Networks>
+								</Affects>
+							</PublishAtScope>
+							<PassengerInformationAction>
+								<PublicationWindow>
+									<StartTime>2020-10-01T13:45:00+02:00</StartTime>
+									<EndTime>2020-10-01T16:00:00+02:00</EndTime>
+								</PublicationWindow>
+								<ActionRef/>
+								<RecordedAtTime>2020-10-01T13:09:00+02:00</RecordedAtTime>
+								<SourceRef>Hochbahn_U_MES_Disponent</SourceRef>
+								<Perspective>journeyPlanner</Perspective>
+								<TextualContent>
+									<TextualContentSize>medium</TextualContentSize>
+									<SummaryContent>
+										<SummaryText xml:lang="DE">U1 Streckensperrung Hauptbahnhof Süd - Jungfernstieg</SummaryText>
+									</SummaryContent>
+									<DescriptionContent>
+										<DescriptionText xml:lang="DE">Wegen eines Poilzei-Einsatzes 
+													ist derzeit keine Beförderung zwischen Hauptbahnhof Süd und Jungfernstieg 
+													in beiden Richtungen möglich. SEV ist eingerichtet, 
+													Verlängerung der Fahrzeit </DescriptionText>
+									</DescriptionContent>
+								</TextualContent>
+								<TextualContent>
+									<TextualContentSize>small</TextualContentSize>
+									<SummaryContent>
+										<SummaryText xml:lang="DE">U1 Streckensperrung Hauptbahnhof Süd - Jungfernstieg</SummaryText>
+									</SummaryContent>
+									<DescriptionContent>
+										<DescriptionText xml:lang="DE">SEV ist eingerichtet, 
+													Verzögerung </DescriptionText>
+									</DescriptionContent>
+								</TextualContent>
+							</PassengerInformationAction>
+						</PublishingAction>
+						<PublishingAction>	<!-- Former matchingInto SEV Ri 1 -->
+							<PublishAtScope>
+								<ScopeType>line</ScopeType>
+								<Affects>
+									<Networks>
+										<AffectedNetwork>
+											<NetworkRef>HHA-U</NetworkRef>
+											<AffectedLine>
+												<LineRef>HHA-U:U1_HHA-U</LineRef>
+												<PublishedLineName xml:lang="DE">U1</PublishedLineName>
+												<Direction>
+													<DirectionRef>1</DirectionRef>
+													<DirectionName>Großhansdorf</DirectionName>
+												</Direction>
+												<Direction>
+													<DirectionRef>1</DirectionRef>
+													<DirectionName>Ohlstedt</DirectionName>
+												</Direction>
+												<StopPlaces>
+													<AffectedStopPlace>
+														<StopPlaceRef>de:02000:11950</StopPlaceRef>
+														<PlaceName xml:lang="DE">Jungfernstieg</PlaceName>
+													</AffectedStopPlace>
+													<AffectedStopPlace>
+														<StopPlaceRef>de:02000:11903</StopPlaceRef>
+														<PlaceName xml:lang="DE">Meßberg</PlaceName>
+													</AffectedStopPlace>
+													<AffectedStopPlace>
+														<StopPlaceRef>de:02000:10907</StopPlaceRef>
+														<PlaceName xml:lang="DE">Steinstraße</PlaceName>
+													</AffectedStopPlace>
+													<AffectedStopPlace>
+														<StopPlaceRef>de:02000:10906</StopPlaceRef>
+														<PlaceName xml:lang="DE">Hauptbahnhof Süd</PlaceName>
+													</AffectedStopPlace>
+												</StopPlaces>
+											</AffectedLine>
+										</AffectedNetwork>
+									</Networks>
+								</Affects>
+							</PublishAtScope>
+							<PassengerInformationAction>
+								<PublicationWindow>
+									<StartTime>2020-10-01T13:45:00+02:00</StartTime>
+									<EndTime>2020-10-01T16:00:00+02:00</EndTime>
+								</PublicationWindow>
+								<ActionRef/>
+								<RecordedAtTime>2020-10-01T13:09:00+02:00</RecordedAtTime>
+								<SourceRef>Hochbahn_U_MES_Disponent</SourceRef>
+								<Perspective>journeyPlanner</Perspective>
+								<TextualContent>
+									<TextualContentSize>medium</TextualContentSize>
+									<SummaryContent>
+										<SummaryText xml:lang="DE">U1 Streckensperrung Hauptbahnhof Süd - Jungfernstieg</SummaryText>
+									</SummaryContent>
+									<DescriptionContent>
+										<DescriptionText xml:lang="DE">Wegen eines Poilzei-Einsatzes 
+													ist derzeit keine Beförderung zwischen Hauptbahnhof Süd und Jungfernstieg 
+													in beiden Richtungen möglich. SEV ist eingerichtet, 
+													Verlängerung der Fahrzeit </DescriptionText>
+									</DescriptionContent>
+								</TextualContent>
+								<TextualContent>
+									<TextualContentSize>small</TextualContentSize>
+									<SummaryContent>
+										<SummaryText xml:lang="DE">U1 Streckensperrung Hauptbahnhof Süd - Jungfernstieg</SummaryText>
+									</SummaryContent>
+									<DescriptionContent>
+										<DescriptionText xml:lang="DE">SEV ist eingerichtet, 
+													Verzögerung </DescriptionText>
+									</DescriptionContent>
+								</TextualContent>
+							</PassengerInformationAction>
+						</PublishingAction>
+					</PublishingActions>
+				</PtSituationElement>
+			</Situations>
+		</SituationExchangeDelivery>
+	</ServiceDelivery>
+</Siri>

--- a/examples/hamburg_example/Use_Case_Ausfall.xml
+++ b/examples/hamburg_example/Use_Case_Ausfall.xml
@@ -1,0 +1,204 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Siri xmlns="http://www.siri.org.uk/siri" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.0" xsi:schemaLocation="http://www.siri.org.uk/siri ../../xsd/siri.xsd">
+	<ServiceDelivery>
+		<ResponseTimestamp>2020-09-08T18:40:00+02:00</ResponseTimestamp>
+		<ProducerRef>MES</ProducerRef>
+		<SituationExchangeDelivery version="2.0">
+			<ResponseTimestamp>2020-09-08T18:40:00+02:00</ResponseTimestamp>
+			<Situations>
+				<PtSituationElement>
+					<CreationTime>2020-09-08T18:40:00+02:00</CreationTime>
+					<ParticipantRef>KVG</ParticipantRef>
+					<SituationNumber>200908001B</SituationNumber>
+					<Version>0</Version>
+					<Source>
+						<SourceType>phone</SourceType>
+						<AgentReference>KVG_MES</AgentReference>
+						<Name xml:lang="DE">KVG_MES_Disponent</Name>
+						<TimeOfCommunication>2020-09-08T18:40:00+02:00</TimeOfCommunication>
+					</Source>
+					<Progress>published</Progress>
+					<ValidityPeriod>
+						<StartTime>2020-09-09T07:28:00+02:00</StartTime>
+						<EndTime>2020-09-09T12:29:00+02:00</EndTime>
+					</ValidityPeriod>
+					<PublicationWindow>
+						<StartTime>2020-09-08T18:40:00+02:00</StartTime>
+						<EndTime>2020-09-09T12:29:00+02:00</EndTime>
+					</PublicationWindow>
+					<AlertCause>miscellaneous</AlertCause>
+					<Priority>3</Priority>
+					<!-- normal -->
+					<Planned>false</Planned>
+					<Summary xml:lang="DE">Ausfall Schulfahrten</Summary>
+					<Description xml:lang="DE">Am 09. September fallen die Fahrten zu und 
+						vom Schulzentrum Bürgerweide wg. eines Heizunmgsschadens aus.</Description>
+					<Affects>
+						<Places>
+							<AffectedPlace>
+								<PlaceName>Schulzentrum Bürgerweide</PlaceName>
+								<Location>
+									<Longitude>53.3640724</Longitude>
+									<Latitude>10.2215785</Latitude>
+								</Location>
+							</AffectedPlace>
+						</Places>
+					</Affects>
+					<Consequences>
+						<Consequence>
+							<!-- cancelled = Fahrt fällt aus -->
+							<Condition>tripCancellation</Condition>
+							<Affects>
+								<VehicleJourneys>
+									<AffectedVehicleJourney>
+										<FramedVehicleJourneyRef>
+											<DataFrameRef>2020-09-09</DataFrameRef>
+											<DatedVehicleJourneyRef>07x28</DatedVehicleJourneyRef>
+										</FramedVehicleJourneyRef>
+										<Operator>
+											<OperatorShortName xml:lang="DE">KVG</OperatorShortName>
+										</Operator>
+										<LineRef>KVG:4406_KVG_NeuKVG</LineRef>
+										<PublishedLineName xml:lang="DE">4406</PublishedLineName>
+										<Origins>
+											<StopPointRef>de:03353:94900::1</StopPointRef>
+											<StopPointName xml:lang="DE">Winsen, Schulzentrum Bürgerweide</StopPointName>
+										</Origins>
+										<Destinations>
+											<StopPointRef>de:03353:96601::1</StopPointRef>
+											<StopPointName xml:lang="DE">Putensen, Lindenallee</StopPointName>
+										</Destinations>
+										<Route>
+											<Direction>
+												<DirectionRef>1</DirectionRef>
+												<DirectionName xml:lang="DE">Salzhausen</DirectionName>
+											</Direction>
+										</Route>
+										<OriginAimedDepartureTime>2020-09-09T07:28:00+02:00</OriginAimedDepartureTime>
+										<DestinationAimedArrivalTime>2020-09-09T08:06:00+02:00</DestinationAimedArrivalTime>
+										<JourneyCondition>tripCancellation</JourneyCondition>
+									</AffectedVehicleJourney>
+									<AffectedVehicleJourney>
+										<FramedVehicleJourneyRef>
+											<DataFrameRef>2020-09-09</DataFrameRef>
+											<DatedVehicleJourneyRef>11x21</DatedVehicleJourneyRef>
+										</FramedVehicleJourneyRef>
+										<Operator>
+											<OperatorShortName xml:lang="DE">KVG</OperatorShortName>
+										</Operator>
+										<LineRef>KVG:4406_KVG_NeuKVG</LineRef>
+										<PublishedLineName xml:lang="DE">4406</PublishedLineName>
+										<Origins>
+											<StopPointRef>de:03353:94900::1</StopPointRef>
+											<StopPointName xml:lang="DE">Winsen, Schulzentrum Bürgerweide</StopPointName>
+										</Origins>
+										<Destinations>
+											<StopPointRef>de:03353:96803::1</StopPointRef>
+											<StopPointName xml:lang="DE">Egestorf, Kirche</StopPointName>
+										</Destinations>
+										<Route>
+											<Direction>
+												<DirectionRef>1</DirectionRef>
+												<DirectionName xml:lang="DE">Egestorf</DirectionName>
+											</Direction>
+										</Route>
+										<OriginAimedDepartureTime>2020-09-09T11:21:00+02:00</OriginAimedDepartureTime>
+										<DestinationAimedArrivalTime>2020-09-09T12:29:00+02:00</DestinationAimedArrivalTime>
+										<JourneyCondition>tripCancellation</JourneyCondition>
+									</AffectedVehicleJourney>
+								</VehicleJourneys>
+							</Affects>
+							<Blocking>
+								<JourneyPlanner>true</JourneyPlanner>	<!-- use this consequence for journey planning -->
+								<RealTime>true</RealTime>							<!-- disable real time for these trips -->
+							</Blocking>
+						</Consequence>
+					</Consequences>
+					<PublishingActions>
+						<PublishingAction>
+							<PublishAtScope>
+								<ScopeType>datedVehicleJourney</ScopeType>
+								<Affects>
+									<VehicleJourneys>
+										<AffectedVehicleJourney>
+											<FramedVehicleJourneyRef>
+												<DataFrameRef>2020-09-09</DataFrameRef>
+												<DatedVehicleJourneyRef>07x28</DatedVehicleJourneyRef>
+											</FramedVehicleJourneyRef>
+											<Operator>
+												<OperatorShortName xml:lang="DE">KVG</OperatorShortName>
+											</Operator>
+											<LineRef>KVG:4406_KVG_NeuKVG</LineRef>
+											<PublishedLineName xml:lang="DE">4406</PublishedLineName>
+											<Origins>
+												<StopPointRef>de:03353:94900::1</StopPointRef>
+												<StopPointName xml:lang="DE">Winsen, Schulzentrum Bürgerweide</StopPointName>
+											</Origins>
+											<Destinations>
+												<StopPointRef>de:03353:96601::1</StopPointRef>
+												<StopPointName xml:lang="DE">Putensen, Lindenallee</StopPointName>
+											</Destinations>
+											<Route>
+												<Direction>
+													<DirectionRef>1</DirectionRef>
+													<DirectionName xml:lang="DE">Winsen, Schulzentrum Bürgerweide</DirectionName>
+												</Direction>
+											</Route>
+											<OriginAimedDepartureTime>2020-09-09T07:28:00+02:00</OriginAimedDepartureTime>
+											<DestinationAimedArrivalTime>2020-09-09T08:06:00+02:00</DestinationAimedArrivalTime>
+											<JourneyCondition>tripCancellation</JourneyCondition>
+										</AffectedVehicleJourney>
+										<AffectedVehicleJourney>
+											<FramedVehicleJourneyRef>
+												<DataFrameRef>2020-09-09</DataFrameRef>
+												<DatedVehicleJourneyRef>11x21</DatedVehicleJourneyRef>
+											</FramedVehicleJourneyRef>
+											<Operator>
+												<OperatorShortName xml:lang="DE">KVG</OperatorShortName>
+											</Operator>
+											<LineRef>KVG:4406_KVG_NeuKVG</LineRef>
+											<PublishedLineName xml:lang="DE">4406</PublishedLineName>
+											<Origins>
+												<StopPointRef>de:03353:94900::1</StopPointRef>
+												<StopPointName xml:lang="DE">Winsen, Schulzentrum Bürgerweide</StopPointName>
+											</Origins>
+											<Destinations>
+												<StopPointRef>de:03353:96803::1</StopPointRef>
+												<StopPointName xml:lang="DE">Egestorf, Kirche</StopPointName>
+											</Destinations>
+											<Route>
+												<Direction>
+													<DirectionRef>1</DirectionRef>
+													<DirectionName xml:lang="DE">Winsen, Schulzentrum Bürgerweide</DirectionName>
+												</Direction>
+											</Route>
+											<OriginAimedDepartureTime>2020-09-09T11:21:00+02:00</OriginAimedDepartureTime>
+											<DestinationAimedArrivalTime>2020-09-09T12:29:00+02:00</DestinationAimedArrivalTime>
+											<JourneyCondition>tripCancellation</JourneyCondition>
+										</AffectedVehicleJourney>
+									</VehicleJourneys>
+								</Affects>
+							</PublishAtScope>
+							<PassengerInformationAction>
+								<ActionRef/>
+								<RecordedAtTime>2020-09-08T18:40:00+02:00</RecordedAtTime>
+								<SourceRef>KVG_MES_Disponent</SourceRef>
+								<Perspective>general</Perspective>
+								<TextualContent>
+									<TextualContentSize>medium</TextualContentSize>
+									<SummaryContent>
+										<SummaryText xml:lang="DE">Ausfall Schulfahrten</SummaryText>
+									</SummaryContent>
+									<DescriptionContent>
+										<DescriptionText xml:lang="DE">Am 09. September fallen die Fahrten zu und 
+											   vom Schulzentrum Bürgerweide wg. eines Heizunmgsschadens aus.</DescriptionText>
+									</DescriptionContent>
+								</TextualContent>
+							</PassengerInformationAction>
+						</PublishingAction>
+					</PublishingActions>
+				</PtSituationElement>
+			</Situations>
+		</SituationExchangeDelivery>
+	</ServiceDelivery>
+</Siri>

--- a/examples/hamburg_example/Use_Case_Durchfahrt_Landungsbruecken.xml
+++ b/examples/hamburg_example/Use_Case_Durchfahrt_Landungsbruecken.xml
@@ -1,0 +1,292 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Siri xmlns="http://www.siri.org.uk/siri" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:acsb="http://www.ifopt.org.uk/acsb" version="2.0" xsi:schemaLocation="http://www.siri.org.uk/siri ../../xsd/siri.xsd">
+	<ServiceDelivery>
+		<ResponseTimestamp>2020-08-14T13:10:00+02:00</ResponseTimestamp>
+		<ProducerRef>MES</ProducerRef>
+		<SituationExchangeDelivery version="2.0">
+			<ResponseTimestamp>2020-08-14T13:10:00+02:00</ResponseTimestamp>
+			<Situations>
+				<PtSituationElement>
+					<CreationTime>2020-08-14T13:10:00+02:00</CreationTime>
+					<ParticipantRef>HHA-U</ParticipantRef>
+					<SituationNumber>181107001A</SituationNumber>
+					<Source>
+						<SourceType>web</SourceType>
+						<AgentReference>HHA-U</AgentReference>
+						<Name xml:lang="DE">HHA MES Disponent</Name>
+						<TimeOfCommunication>2020-08-14T13:10:00+02:00</TimeOfCommunication>
+					</Source>
+					<Progress>published</Progress>
+					<ValidityPeriod>
+						<StartTime>2020-09-05T04:00:00+02:00</StartTime>
+						<EndTime>2020-12-06T23:59:00+01:00</EndTime>
+					</ValidityPeriod>
+					<PublicationWindow>
+						<StartTime>2020-08-17T00:00:00+02:00</StartTime>
+						<EndTime>2020-12-06T23:59:00+01:00</EndTime>
+					</PublicationWindow>
+					<AlertCause>policeActivity</AlertCause>
+					<Priority>3</Priority>  <!-- normal -->
+					<Planned>true</Planned>
+					<Summary xml:lang="DE">Bauarbeiten an Haltestelle Landungsbrücken</Summary>
+					<Description xml:lang="DE">Barrierefreier Ausbau dieser Haltestelle, 
+												Instandsetzungsarbeiten an der Haltestelle.
+												Deshalb fahren die U-Bahnen der Linie U3 an dieser Haltestelle durch.
+												Da das RBL der U-Bahn den Halt an dieser Haltestelle weiterhin anzeigt, 
+												muß die Echtzeit-Anzeige an dieser Haltestelle de-aktiviert werden.</Description>
+					<Affects>
+						<StopPlaces>
+							<AffectedStopPlace>
+								<StopPlaceRef>de:02000:80950</StopPlaceRef>
+								<PlaceName xml:lang="DE">Landungsbrücken</PlaceName>
+							</AffectedStopPlace>
+						</StopPlaces>
+					</Affects>
+					<Consequences>
+						<Consequence>
+							<!-- stopCancelled = Haltestelle wird nicht bedient / durchfahrt -->
+							<Condition>stopCancelled</Condition>
+							<Affects>
+								<Networks>
+									<AffectedNetwork>
+										<AffectedOperator>
+											<OperatorShortName xml:lang="DE">HHA-U</OperatorShortName>
+										</AffectedOperator>
+										<AffectedLine>
+											<LineRef>HHA-U:U3_HHA-U</LineRef>
+											<PublishedLineName xml:lang="DE">U3</PublishedLineName>
+											<StopPoints>
+												<AffectedStopPoint>
+													<StopPointRef>de:02000:80950::1</StopPointRef>
+													<StopPointName xml:lang="DE">Landungsbrücken</StopPointName>
+												</AffectedStopPoint>
+												<AffectedStopPoint>
+													<StopPointRef>de:02000:80950::2</StopPointRef>
+													<StopPointName xml:lang="DE">Landungsbrücken</StopPointName>
+												</AffectedStopPoint>
+											</StopPoints>
+										</AffectedLine>
+									</AffectedNetwork>
+								</Networks>
+							</Affects>
+							<Blocking>
+								<JourneyPlanner>true</JourneyPlanner>
+								<!-- use this consequence for journey planning -->
+								<RealTime>true</RealTime>
+								<!-- disable real time for that stoppoint -->
+							</Blocking>
+						</Consequence>
+					</Consequences>
+					<PublishingActions>
+						<PublishingAction>
+							<PublishAtScope>
+								<ScopeType>line</ScopeType>
+								<Affects>
+									<Networks>
+										<AffectedNetwork>
+											<NetworkRef>HHA</NetworkRef>
+											<AffectedLine>
+												<LineRef>HHA-U:U3_HHA-U</LineRef>
+												<PublishedLineName xml:lang="DE">U3</PublishedLineName>
+												<Direction>
+													<DirectionRef>1</DirectionRef>
+													<DirectionName xml:lang="DE">Barmbek</DirectionName>
+												</Direction>
+												<Direction>
+													<DirectionRef>6</DirectionRef>
+													<DirectionName xml:lang="DE">Wandsbek-Gartenstadt</DirectionName>
+												</Direction>
+											</AffectedLine>
+										</AffectedNetwork>
+									</Networks>
+								</Affects>
+							</PublishAtScope>
+							<PassengerInformationAction>
+								<PublicationWindow>
+									<StartTime>2020-08-17T00:00:00+02:00</StartTime>
+									<EndTime>2020-09-05T04:00:00+02:00</EndTime>
+								</PublicationWindow>
+								<ActionRef/>
+								<RecordedAtTime>2020-08-14T13:09:00+02:00</RecordedAtTime>
+								<SourceRef>HHA_MES_DISPONENT</SourceRef>
+								<Perspective>general</Perspective>
+								<TextualContent>
+									<TextualContentSize>medium</TextualContentSize>
+									<SummaryContent>
+										<SummaryText xml:lang="DE">Ankündigung: U3 Landungsbrücken ohne Halt 
+												in beiden Richtungen.</SummaryText>
+									</SummaryContent>
+									<DescriptionContent>
+										<DescriptionText xml:lang="DE">Von Sonnabend, 5. September, bis Sonntag, 6. Dezember, 
+												fährt die U3 in beiden Richtungen ohne Halt durch die 
+												Haltestelle Landungsbrücken.</DescriptionText>
+									</DescriptionContent>
+								</TextualContent>
+								<TextualContent>
+									<TextualContentSize>small</TextualContentSize>
+									<SummaryContent>
+										<SummaryText xml:lang="DE">Ankündigung: U3 Landungsbrücken ohne Halt</SummaryText>
+									</SummaryContent>
+									<DescriptionContent>
+										<DescriptionText xml:lang="DE">Vom 5. 9. bis 6. 12. 
+												U3 ohne Halt in	Hst. Landungsbrücken.</DescriptionText>
+									</DescriptionContent>
+								</TextualContent>
+							</PassengerInformationAction>
+						</PublishingAction>
+						<PublishingAction>
+							<PublishAtScope>
+								<ScopeType>stopPoint</ScopeType>
+								<Affects>
+									<Networks>
+										<AffectedNetwork>
+											<NetworkRef>HHA</NetworkRef>
+											<AffectedLine>
+												<LineRef>HHA-U:U3_HHA-U</LineRef>
+												<PublishedLineName xml:lang="DE">U3</PublishedLineName>
+												<Direction>
+													<DirectionRef>1</DirectionRef>
+													<DirectionName xml:lang="DE">Barmbek</DirectionName>
+												</Direction>
+												<Direction>
+													<DirectionRef>6</DirectionRef>
+													<DirectionName xml:lang="DE">Wandsbek-Gartenstadt</DirectionName>
+												</Direction>
+												<StopPoints>
+													<AffectedStopPoint>
+														<StopPointRef>de:02000:80950::1</StopPointRef>
+														<StopPointName xml:lang="DE">Landungsbrücken</StopPointName>
+													</AffectedStopPoint>
+													<AffectedStopPoint>
+														<StopPointRef>de:02000:80950::2</StopPointRef>
+														<StopPointName xml:lang="DE">Landungsbrücken</StopPointName>
+													</AffectedStopPoint>
+												</StopPoints>
+											</AffectedLine>
+										</AffectedNetwork>
+									</Networks>
+								</Affects>
+							</PublishAtScope>
+							<PassengerInformationAction>
+								<PublicationWindow>
+									<StartTime>2020-09-05T04:00:00+02:00</StartTime>
+									<EndTime>2020-12-06T23:59:00+01:00</EndTime>
+								</PublicationWindow>
+								<ActionRef/>
+								<RecordedAtTime>2020-08-14T13:09:00+02:00</RecordedAtTime>
+								<SourceRef>HHA_MES_DISPONENT</SourceRef>
+								<Perspective>general</Perspective>
+								<TextualContent>
+									<TextualContentSize>large</TextualContentSize>
+									<SummaryContent>
+										<SummaryText xml:lang="DE">U3 Landungsbrücken ohne Halt 
+												in beiden Richtungen.</SummaryText>
+									</SummaryContent>
+									<DescriptionContent>
+										<DescriptionText xml:lang="DE">Von Sonnabend, 5. September, bis Sonntag, 6. Dezember, 
+												fährt die U3 in beiden Richtungen ohne Halt durch die 
+												Haltestelle Landungsbrücken.
+												Grund hierfür sind der barrierefreie Ausbau und 
+												Instandsetzungsarbeiten an der Haltestelle.</DescriptionText>
+									</DescriptionContent>
+								</TextualContent>
+								<TextualContent>
+									<TextualContentSize>medium</TextualContentSize>
+									<SummaryContent>
+										<SummaryText xml:lang="DE">U3 Landungsbrücken ohne Halt 
+												in beiden Richtungen.</SummaryText>
+									</SummaryContent>
+									<DescriptionContent>
+										<DescriptionText xml:lang="DE">Von Sonnabend, 5. September, bis Sonntag, 6. Dezember, 
+												fährt die U3 in beiden Richtungen ohne Halt durch die 
+												Haltestelle Landungsbrücken.</DescriptionText>
+									</DescriptionContent>
+								</TextualContent>
+								<TextualContent>
+									<TextualContentSize>small</TextualContentSize>
+									<SummaryContent>
+										<SummaryText xml:lang="DE">U3 Landungsbrücken ohne Halt</SummaryText>
+									</SummaryContent>
+									<DescriptionContent>
+										<DescriptionText xml:lang="DE">Vom 5. 9. bis 6. 12. 
+												U3 ohne Halt in	Hst. Landungsbrücken.</DescriptionText>
+									</DescriptionContent>
+								</TextualContent>
+							</PassengerInformationAction>
+						</PublishingAction>
+						<PublishingAction>
+							<PublishAtScope>
+								<ScopeType>stopPlace</ScopeType>
+								<Affects>
+									<Networks>
+										<AffectedNetwork>
+											<NetworkRef>HHA</NetworkRef>
+											<AffectedLine>
+												<LineRef>HHA-U:U3_HHA-U</LineRef>
+												<PublishedLineName xml:lang="DE">U3</PublishedLineName>
+												<Direction>
+													<DirectionRef>1</DirectionRef>
+													<DirectionName xml:lang="DE">Barmbek</DirectionName>
+												</Direction>
+												<Direction>
+													<DirectionRef>6</DirectionRef>
+													<DirectionName xml:lang="DE">Wandsbek-Gartenstadt</DirectionName>
+												</Direction>
+											</AffectedLine>
+										</AffectedNetwork>
+									</Networks>
+								</Affects>
+							</PublishAtScope>
+							<PassengerInformationAction>
+								<PublicationWindow>
+									<StartTime>2020-08-17T00:00:00+02:00</StartTime>
+									<EndTime>2020-12-06T23:59:00+01:00</EndTime>
+								</PublicationWindow>
+								<ActionRef/>
+								<RecordedAtTime>2020-08-14T13:09:00+02:00</RecordedAtTime>
+								<SourceRef>HHA_MES_DISPONENT</SourceRef>
+								<Perspective>stopPoint</Perspective>
+								<TextualContent>
+									<TextualContentSize>large</TextualContentSize>
+									<SummaryContent>
+										<SummaryText xml:lang="DE">U3 Landungsbrücken ohne Halt 
+												in beiden Richtungen.</SummaryText>
+									</SummaryContent>
+									<DescriptionContent>
+										<DescriptionText xml:lang="DE">Von Sonnabend, 5. September, bis Sonntag, 6. Dezember, 
+												fährt die U3 in beiden Richtungen ohne Halt durch die 
+												Haltestelle Landungsbrücken.
+												Grund hierfür sind der barrierefreie Ausbau und 
+												Instandsetzungsarbeiten an der Haltestelle.</DescriptionText>
+									</DescriptionContent>
+								</TextualContent>
+								<TextualContent>
+									<TextualContentSize>medium</TextualContentSize>
+									<SummaryContent>
+										<SummaryText xml:lang="DE">U3 Landungsbrücken ohne Halt 
+												in beiden Richtungen.</SummaryText>
+									</SummaryContent>
+									<DescriptionContent>
+										<DescriptionText xml:lang="DE">Von Sonnabend, 5. September, bis Sonntag, 6. Dezember, 
+												fährt die U3 in beiden Richtungen ohne Halt durch die 
+												Haltestelle Landungsbrücken.</DescriptionText>
+									</DescriptionContent>
+								</TextualContent>
+								<TextualContent>
+									<TextualContentSize>small</TextualContentSize>
+									<SummaryContent>
+										<SummaryText xml:lang="DE"> </SummaryText>
+									</SummaryContent>
+									<DescriptionContent>
+										<DescriptionText xml:lang="DE">Vom 5. 9. bis 6. 12. 
+												U3 ohne Halt in	Landungsbrücken.</DescriptionText>
+									</DescriptionContent>
+								</TextualContent>
+							</PassengerInformationAction>
+						</PublishingAction>
+					</PublishingActions>
+				</PtSituationElement>
+			</Situations>
+		</SituationExchangeDelivery>
+	</ServiceDelivery>
+</Siri>

--- a/xsd/Siri-2.0.spp
+++ b/xsd/Siri-2.0.spp
@@ -224,5 +224,13 @@
 			<File FilePath="..\examples\siri_exu_capability\exd_allServices_capabilitiesRequest.xml" HomeFolder="Yes"/>
 			<File FilePath="..\examples\siri_exu_capability\exd_allServices_capabilitiesResponse.xml" HomeFolder="Yes"/>
 		</Folder>
+		<Folder FolderName="hamburg_example">
+		  <File FilePath="..\examples\hamburg_example\Use_Case_Ausfall.xml" HomeFolder="Yes"/>
+		  <File FilePath="..\examples\hamburg_example\Use_Case_Durchfahrt_Landungsbruecken.xml" HomeFolder="Yes"/>
+		  <File FilePath="..\examples\hamburg_example\Use_Case_Abkehren1Seitig_S1_global_initial.xml" HomeFolder="Yes"/>
+		  <File FilePath="..\examples\hamburg_example\Use_Case_Abkehren1Seitig_S1_global_nur_Ausfall.xml" HomeFolder="Yes"/>
+		  <File FilePath="..\examples\hamburg_example\Use_Case_Abkehren1Seitig_S1_global_SEV.xml" HomeFolder="Yes"/>
+		  <File FilePath="..\examples\hamburg_example\Use_Case_Abkehren2Seitig_U1_global_SEV.xml" HomeFolder="Yes"/>
+		</Folder>
 	</Folder>
 </Project>

--- a/xsd/siri_model/siri_situation-v2.0.xsd
+++ b/xsd/siri_model/siri_situation-v2.0.xsd
@@ -1191,6 +1191,11 @@ Rail transport, Roads and road transport
      <xsd:documentation>Description of fare exceptions allowed because of disruption.</xsd:documentation>
     </xsd:annotation>
    </xsd:element>
+   <xsd:element name="PredictableDelays" type="PredictableDelaysStructure" minOccurs="0">
+       <xsd:annotation>
+           <xsd:documentation>Delay at specified stop as result of this Consequence</xsd:documentation>
+       </xsd:annotation>
+   </xsd:element>
    <xsd:element ref="Extensions" minOccurs="0"/>
   </xsd:sequence>
  </xsd:complexType>
@@ -1309,6 +1314,73 @@ Rail transport, Roads and road transport
    </xsd:element>
   </xsd:sequence>
  </xsd:complexType>
+ <!--==PredictableDelays =========================================== -->
+ <xsd:complexType name="PredictableDelaysStructure">
+  <xsd:annotation>
+      <xsd:documentation>Type for defining the delay at different stops.</xsd:documentation>
+  </xsd:annotation>
+  <xsd:sequence>
+      <xsd:element name="PredictableDelay" type="PredictableDelayStructure" minOccurs="0" maxOccurs="unbounded">
+          <xsd:annotation>
+              <xsd:documentation>Additional journey time needed to overcome disruption.</xsd:documentation>
+          </xsd:annotation>
+      </xsd:element>
+  </xsd:sequence>
+  </xsd:complexType>
+   <xsd:complexType name="PredictableDelayStructure">
+		<xsd:annotation>
+			<xsd:documentation>Type for defining the delay at one stop.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:choice>
+				<xsd:element name="AffectedStopPoint" type="AffectedStopPointStructure">
+					<xsd:annotation>
+						<xsd:documentation>Stop affected by Consequence.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+				<xsd:element name="AffectedStopPlace" type="AffectedStopPlaceStructure">
+					<xsd:annotation>
+						<xsd:documentation>Stop affected by Consequence.</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+			</xsd:choice>
+			<xsd:element name="ArrivalTravelProlongation" type="PositiveDurationType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Additional travel time needed to achieve arriving at specified stop</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="ArrivalTravelDuration" type="PositiveDurationType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Travel time needed from start to arrive at specified stop</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="DepartureTravelProlongation" type="PositiveDurationType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Additional journey time needed to achieve departing from specified stop</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="DepartureTravelDuration" type="PositiveDurationType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Travel time needed from start to depart at specified stop</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="CheckInTime" type="PositiveDurationType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Time required to change into the replacement ride</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="CheckOutTime" type="PositiveDurationType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Time required to change from the replacement ride</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="DepartureInterval" type="PositiveDurationType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Time interval between consecutive replacement rides if not correlated to the original departure</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
  <!-- ======================================================================= -->
  <!-- ======================================================================= -->
 </xsd:schema>

--- a/xsd/siri_model/siri_situationActions-v2.0.xsd
+++ b/xsd/siri_model/siri_situationActions-v2.0.xsd
@@ -863,6 +863,8 @@ Rail transport, Roads and road transport
    <xsd:enumeration value="general"/>
    <xsd:enumeration value="stopPoint"/>
    <xsd:enumeration value="vehicleJourney"/>
+   <xsd:enumeration value="journeyPlanner"/>
+   <xsd:enumeration value="generalExceptJourneyPlanner"/>
   </xsd:restriction>
  </xsd:simpleType>
 </xsd:schema>

--- a/xsd/siri_model/siri_situationClassifiers-v1.1.xsd
+++ b/xsd/siri_model/siri_situationClassifiers-v1.1.xsd
@@ -162,6 +162,7 @@ Rail transport, Roads and road transport
    <xsd:enumeration value="temporarilyNonStopping"/>
    <xsd:enumeration value="temporaryStopplace"/>
    <xsd:enumeration value="undefinedStatus"/>
+   <xsd:enumeration value="predictableDelay"/>
   </xsd:restriction>
  </xsd:simpleType>
  <!-- ==Verification================================= -->


### PR DESCRIPTION
Um bei Streckensperrungen die Betriebsfälle einseitiges und zweiseitiges Abkehren optional mit SEV-Fahrten in der Schnittstelle hinreichend detailliert emulieren zu können, sind zusätzliche Elemente und Werte notwendig.